### PR TITLE
Remove generic invocation of sizeOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.2
+
+* Migrates `dart:ffi`s generic `sizeOf` uses, which will be removed in Dart 2.13.
+
 # 0.5.1
  * Uses `package:ffigen` to generate the Dart bindings.
  * Bumped SDK constraint to Dart 2.12.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -436,7 +436,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.1"
+    version: "0.5.2"
   webdriver:
     dependency: transitive
     description:

--- a/lib/src/impl_ffi/impl_ffi.aescbc.dart
+++ b/lib/src/impl_ffi/impl_ffi.aescbc.dart
@@ -59,16 +59,16 @@ Stream<Uint8List> _aesCbcEncryptOrDecrypt(
     const bufSize = 4096;
 
     // Allocate an input buffer
-    final inBuf = scope.allocate<ffi.Uint8>(count: bufSize);
+    final inBuf = scope<ffi.Uint8>(bufSize);
     final inData = inBuf.asTypedList(bufSize);
 
     // Allocate an output buffer, notice that BoringSSL says output cannot be
     // more than input size + blockSize - 1
-    final outBuf = scope.allocate<ffi.Uint8>(count: bufSize + blockSize);
+    final outBuf = scope<ffi.Uint8>(bufSize + blockSize);
     final outData = outBuf.asTypedList(bufSize + blockSize);
 
     // Allocate and output length integer
-    final outLen = scope.allocate<ffi.Int32>();
+    final outLen = scope<ffi.Int32>();
 
     // Process data from source
     await for (final data in source) {

--- a/lib/src/impl_ffi/impl_ffi.aesctr.dart
+++ b/lib/src/impl_ffi/impl_ffi.aesctr.dart
@@ -104,16 +104,16 @@ Stream<Uint8List> _aesCtrEncryptOrDecrypt(
     const bufSize = 4096;
 
     // Allocate an input buffer
-    final inBuf = scope.allocate<ffi.Uint8>(count: bufSize);
+    final inBuf = scope<ffi.Uint8>(bufSize);
     final inData = inBuf.asTypedList(bufSize);
 
     // Allocate an output buffer, notice that BoringSSL says output cannot be
     // more than input size + blockSize - 1
-    final outBuf = scope.allocate<ffi.Uint8>(count: bufSize + blockSize);
+    final outBuf = scope<ffi.Uint8>(bufSize + blockSize);
     final outData = outBuf.asTypedList(bufSize + blockSize);
 
     // Allocate and output length integer
-    final outLen = scope.allocate<ffi.Int32>();
+    final outLen = scope<ffi.Int32>();
 
     // Process data from source
     var isBeforeWrapAround = true;

--- a/lib/src/impl_ffi/impl_ffi.aesgcm.dart
+++ b/lib/src/impl_ffi/impl_ffi.aesgcm.dart
@@ -74,7 +74,7 @@ Future<Uint8List> _aesGcmEncryptDecrypt(
     );
 
     if (isEncrypt) {
-      final outLen = scope.allocate<ffi.IntPtr>();
+      final outLen = scope<ffi.IntPtr>();
       final maxOut = data.length + ssl.EVP_AEAD_max_overhead(aead);
       return _withOutPointer(maxOut, (ffi.Pointer<ffi.Uint8> out) {
         _checkOpIsOne(ssl.EVP_AEAD_CTX_seal(
@@ -91,7 +91,7 @@ Future<Uint8List> _aesGcmEncryptDecrypt(
         ));
       }).sublist(0, outLen.value);
     } else {
-      final outLen = scope.allocate<ffi.IntPtr>();
+      final outLen = scope<ffi.IntPtr>();
       return _withOutPointer(data.length, (ffi.Pointer<ffi.Uint8> out) {
         _checkOpIsOne(ssl.EVP_AEAD_CTX_open(
           ctx,

--- a/lib/src/impl_ffi/impl_ffi.dart
+++ b/lib/src/impl_ffi/impl_ffi.dart
@@ -16,6 +16,7 @@
 library impl_ffi;
 
 import 'dart:async';
+import 'dart:ffi' show Allocator;
 import 'dart:typed_data';
 import 'dart:convert' show utf8, base64Url;
 import 'dart:ffi' as ffi;

--- a/lib/src/impl_ffi/impl_ffi.ecdsa.dart
+++ b/lib/src/impl_ffi/impl_ffi.ecdsa.dart
@@ -108,7 +108,8 @@ Uint8List _convertEcdsaDerSignatureToWebCryptoSignature(
       ec,
     )));
 
-    return _withAllocation(2, (ffi.Pointer<ffi.Pointer<BIGNUM>> RS) {
+    return _withAllocation(_sslAlloc<ffi.Pointer<BIGNUM>>(2),
+        (ffi.Pointer<ffi.Pointer<BIGNUM>> RS) {
       // Access R and S from the ecdsa signature
       final R = RS.elementAt(0);
       final S = RS.elementAt(1);
@@ -164,7 +165,8 @@ Uint8List? _convertEcdsaWebCryptoSignatureToDerSignature(
         message: 'internal error formatting signature');
     scope.defer(() => ssl.ECDSA_SIG_free(ecdsa));
 
-    return _withAllocation(2, (ffi.Pointer<ffi.Pointer<BIGNUM>> RS) {
+    return _withAllocation(_sslAlloc<ffi.Pointer<BIGNUM>>(2),
+        (ffi.Pointer<ffi.Pointer<BIGNUM>> RS) {
       // Access R and S from the ecdsa signature
       final R = RS.elementAt(0);
       final S = RS.elementAt(1);
@@ -214,7 +216,8 @@ class _EcdsaPrivateKey implements EcdsaPrivateKey {
       );
 
       await _streamToUpdate(data, ctx, ssl.EVP_DigestSignUpdate);
-      return _withAllocation(1, (ffi.Pointer<ffi.IntPtr> len) {
+      return _withAllocation(_sslAlloc<ffi.IntPtr>(),
+          (ffi.Pointer<ffi.IntPtr> len) {
         len.value = 0;
         _checkOpIsOne(ssl.EVP_DigestSignFinal(ctx, ffi.nullptr, len));
         return _withOutPointer(len.value, (ffi.Pointer<ffi.Uint8> p) {

--- a/lib/src/impl_ffi/impl_ffi.hmac.dart
+++ b/lib/src/impl_ffi/impl_ffi.hmac.dart
@@ -126,7 +126,8 @@ class _HmacSecretKey implements HmacSecretKey {
 
       final size = ssl.HMAC_size(ctx);
       _checkOp(size > 0);
-      return _withAllocation(1, (ffi.Pointer<ffi.Uint32> psize) async {
+      return _withAllocation(_sslAlloc<ffi.Uint32>(),
+          (ffi.Pointer<ffi.Uint32> psize) async {
         psize.value = size;
         return _withOutPointer(size, (ffi.Pointer<ffi.Uint8> p) {
           _checkOp(ssl.HMAC_Final(ctx, p, psize) == 1);

--- a/lib/src/impl_ffi/impl_ffi.random.dart
+++ b/lib/src/impl_ffi/impl_ffi.random.dart
@@ -19,7 +19,8 @@ void fillRandomBytes(TypedData destination) {
     destination.offsetInBytes,
     destination.lengthInBytes,
   );
-  _withAllocation(dest.length, (ffi.Pointer<ffi.Uint8> p) {
+  _withAllocation(_sslAlloc<ffi.Uint8>(dest.length),
+      (ffi.Pointer<ffi.Uint8> p) {
     _checkOp(ssl.RAND_bytes(p, dest.length) == 1);
     dest.setAll(0, p.asTypedList(dest.length));
   });

--- a/lib/src/impl_ffi/impl_ffi.rsa_common.dart
+++ b/lib/src/impl_ffi/impl_ffi.rsa_common.dart
@@ -194,8 +194,8 @@ Map<String, dynamic> _exportJwkRsaPrivateOrPublicKey(
     }
 
     // Public key parameters
-    final n = scope.allocate<ffi.Pointer<BIGNUM>>();
-    final e = scope.allocate<ffi.Pointer<BIGNUM>>();
+    final n = scope<ffi.Pointer<BIGNUM>>();
+    final e = scope<ffi.Pointer<BIGNUM>>();
     ssl.RSA_get0_key(rsa, n, e, ffi.nullptr);
 
     if (!isPrivateKey) {
@@ -208,19 +208,19 @@ Map<String, dynamic> _exportJwkRsaPrivateOrPublicKey(
       ).toJson();
     }
 
-    final d = scope.allocate<ffi.Pointer<BIGNUM>>();
+    final d = scope<ffi.Pointer<BIGNUM>>();
     ssl.RSA_get0_key(rsa, ffi.nullptr, ffi.nullptr, d);
 
     // p, q, dp, dq, qi is optional in:
     // // https://tools.ietf.org/html/rfc7518#section-6.3.2
     // but explicitly required when exporting in Web Crypto.
-    final p = scope.allocate<ffi.Pointer<BIGNUM>>();
-    final q = scope.allocate<ffi.Pointer<BIGNUM>>();
+    final p = scope<ffi.Pointer<BIGNUM>>();
+    final q = scope<ffi.Pointer<BIGNUM>>();
     ssl.RSA_get0_factors(rsa, p, q);
 
-    final dp = scope.allocate<ffi.Pointer<BIGNUM>>();
-    final dq = scope.allocate<ffi.Pointer<BIGNUM>>();
-    final qi = scope.allocate<ffi.Pointer<BIGNUM>>();
+    final dp = scope<ffi.Pointer<BIGNUM>>();
+    final dq = scope<ffi.Pointer<BIGNUM>>();
+    final qi = scope<ffi.Pointer<BIGNUM>>();
     ssl.RSA_get0_crt_params(rsa, dp, dq, qi);
 
     return JsonWebKey(

--- a/lib/src/impl_ffi/impl_ffi.rsaoaep.dart
+++ b/lib/src/impl_ffi/impl_ffi.rsaoaep.dart
@@ -149,7 +149,8 @@ Future<Uint8List> _rsaOaepeEncryptOrDecryptBytes(
     }
 
     return _withDataAsPointer(data, (ffi.Pointer<ffi.Uint8> input) {
-      return _withAllocation(1, (ffi.Pointer<ffi.IntPtr> len) {
+      return _withAllocation(_sslAlloc<ffi.IntPtr>(),
+          (ffi.Pointer<ffi.IntPtr> len) {
         len.value = 0;
         _checkOpIsOne(encryptOrDecryptFn(
           ctx,

--- a/lib/src/impl_ffi/impl_ffi.rsapss.dart
+++ b/lib/src/impl_ffi/impl_ffi.rsapss.dart
@@ -137,7 +137,8 @@ class _RsaPssPrivateKey implements RsaPssPrivateKey {
         ));
         _checkDataIsOne(ssl.EVP_PKEY_CTX_set_rsa_mgf1_md(pctx.value, _hash.MD));
         await _streamToUpdate(data, ctx, ssl.EVP_DigestSignUpdate);
-        return _withAllocation(1, (ffi.Pointer<ffi.IntPtr> len) {
+        return _withAllocation(_sslAlloc<ffi.IntPtr>(),
+            (ffi.Pointer<ffi.IntPtr> len) {
           len.value = 0;
           _checkOpIsOne(ssl.EVP_DigestSignFinal(ctx, ffi.nullptr, len));
           return _withOutPointer(len.value, (ffi.Pointer<ffi.Uint8> p) {

--- a/lib/src/impl_ffi/impl_ffi.rsassapkcs1v15.dart
+++ b/lib/src/impl_ffi/impl_ffi.rsassapkcs1v15.dart
@@ -123,7 +123,8 @@ class _RsassaPkcs1V15PrivateKey implements RsassaPkcs1V15PrivateKey {
           ssl.EVP_PKEY_CTX_set_rsa_padding(pctx.value, RSA_PKCS1_PADDING),
         );
         await _streamToUpdate(data, ctx, ssl.EVP_DigestSignUpdate);
-        return _withAllocation(1, (ffi.Pointer<ffi.IntPtr> len) {
+        return _withAllocation(_sslAlloc<ffi.IntPtr>(),
+            (ffi.Pointer<ffi.IntPtr> len) {
           len.value = 0;
           _checkOpIsOne(ssl.EVP_DigestSignFinal(ctx, ffi.nullptr, len));
           return _withOutPointer(len.value, (ffi.Pointer<ffi.Uint8> p) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: webcrypto
-version: 0.5.1
+version: 0.5.2
 description: Cross-platform implementation of Web Cryptography APIs for Flutter.
 homepage: https://github.com/google/webcrypto.dart
 


### PR DESCRIPTION
Support for invoking `sizeOf<T>` with a generic `T` will be removed in Dart 2.13.  