### PR TITLE
Fix: setup.dart failed to run under Linux

### DIFF
--- a/bin/setup.dart
+++ b/bin/setup.dart
@@ -63,7 +63,8 @@ void main() async {
     'cmake',
     [
       '-S',
-      webcryptoRoot.resolve('src').toFilePath(),
+      Directory(webcryptoRoot.toFilePath() + Platform.pathSeparator + 'src')
+          .path,
       '-B',
       root.resolve('.dart_tool/webcrypto').toFilePath(),
     ],

--- a/bin/setup.dart
+++ b/bin/setup.dart
@@ -63,7 +63,7 @@ void main() async {
     'cmake',
     [
       '-S',
-      Directory(webcryptoRoot.toFilePath() + Platform.pathSeparator + 'src')
+      Directory(joinPaths(webcryptoRoot.toFilePath(), 'src'))
           .path,
       '-B',
       root.resolve('.dart_tool/webcrypto').toFilePath(),
@@ -98,4 +98,12 @@ void main() async {
   print('Package webcrypto now configured for use in your project.');
   print('This is only necessary for using package:webcrypto in unit tests');
   print('and scripts, not for usage in applications.');
+}
+
+/// Join paths without duplicate path separators.
+String joinPaths(String prefix, String suffix) {
+  if (!prefix.endsWith(Platform.pathSeparator)) {
+    prefix += Platform.pathSeparator;
+  }
+  return prefix + suffix;
 }

--- a/bin/setup.dart
+++ b/bin/setup.dart
@@ -63,7 +63,7 @@ void main() async {
     'cmake',
     [
       '-S',
-      Directory(joinPaths(webcryptoRoot.toFilePath(), 'src'))
+      Directory(_joinPaths(webcryptoRoot.toFilePath(), 'src'))
           .path,
       '-B',
       root.resolve('.dart_tool/webcrypto').toFilePath(),
@@ -101,7 +101,7 @@ void main() async {
 }
 
 /// Join paths without duplicate path separators.
-String joinPaths(String prefix, String suffix) {
+String _joinPaths(String prefix, String suffix) {
   if (!prefix.endsWith(Platform.pathSeparator)) {
     prefix += Platform.pathSeparator;
   }


### PR DESCRIPTION
`webcryptoRoot.resolve('src')` did not get evaluated to `$PUB_CACHE/webcrypto-x.y.z/src`, but just to `$PUB_CACHE/src`. This broke `flutter pub run webcrypto:setup` at the very least on Linux, but probably on more systems as well. Replacing the URI.resolve approach with a simple string concatenation fixes the bug.

Fixes https://github.com/google/webcrypto.dart/issues/20