### PR TITLE
Enable mac tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,9 +55,8 @@ jobs:
       - run: flutter pub run webcrypto:setup
       - run: flutter test
       - run: flutter test --platform chrome
-      # TODO: Enable macos desktop when supported
-      #- run: flutter test integration_test/webcrypto_test.dart -d macos
-      #  working-directory: ./example
+      - run: flutter test integration_test/webcrypto_test.dart -d macos
+        working-directory: ./example
       - uses: nanasess/setup-chromedriver@v2
       - name: Run integration_test with chromedriver
         working-directory: ./example

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ browser, this package features a native implementation embedding
 web browser this package wraps the [`window.crypto`][window-crypto] APIs and
 providing the same Dart API as the native implementation.
 
-This way, `package:webcrypto` provides the same crypto API on multiple
-platforms. Initially targeting Flutter for **Android**, **iOS** and **Web**,
-with other platforms following as soon as the build system allows.
+This way, `package:webcrypto` provides the same crypto API on **Android**, **iOS**, **Web**, **Windows**, **Linux** and **Mac**.
 
 **Example**
 ```dart

--- a/lib/src/webcrypto/webcrypto.hmac.dart
+++ b/lib/src/webcrypto/webcrypto.hmac.dart
@@ -197,7 +197,7 @@ abstract class HmacSecretKey {
   /// timing attacks. To validate signatures use [verifyBytes] or [verifyStream]
   /// instead, these methods computes a signature and does a
   /// fixed-time comparison.
-  /// {@template}
+  /// {@endtemplate}
   Future<Uint8List> signBytes(List<int> data);
 
   /// Compute an HMAC signature of given [data] stream.


### PR DESCRIPTION
When the example app is not in the background during the test, all tests are green on my local mac. Furthermore I was able to successfully execute the *tests.yml* workflow on Github Actions without any relevant change. I hope that this can be reproduced on the main branch and #74 is fixed.

![image](https://github.com/google/webcrypto.dart/assets/23655672/b097e10b-05b3-4b1a-aa52-e1330bed4119)

Finally, I have fixed a warning and adjusted the readme regarding the supported platforms. 

