### PR TITLE
Add namespace to `build.gradle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.5.5
+* Adds a namespace in `build.gradle` for compatibility with AGP 8.0.
+
 # 0.5.4
 * Added MacOS desktop support.
 * Added Windows desktop support.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'dev.google.webcrypto'
+    }
+
     compileSdkVersion 31
 
     // We depend on cmake for the native parts.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: webcrypto
-version: 0.5.4
+version: 0.5.5
 description: Cross-platform implementation of Web Cryptography APIs for Flutter.
 repository: https://github.com/google/webcrypto.dart
 


### PR DESCRIPTION
Fixes https://github.com/google/webcrypto.dart/issues/84

Full disclosure, I'm not sure what the `namespace` is supposed to be. But I'll guess that nobody is using `dev.google.webcrypto`.

Follows changes from:
 * https://github.com/flutter/packages/commit/6284c2d4e46a5d289e77cb03a9457543b97f750b
 * https://github.com/flutter/packages/commit/a86beafa8912609275225847198c9c0164957d09