### PR TITLE
Migrate lib/src/crypto_subtle.dart to use `dart:js_interop`

### DIFF
--- a/lib/src/crypto_subtle.dart
+++ b/lib/src/crypto_subtle.dart
@@ -113,7 +113,7 @@ extension type JSSubtleCrypto(JSObject _) implements JSObject {
 
   /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/generateKey
   @JS('generateKey')
-  external JSPromise<JSCryptoKey> generateCreptoKey(
+  external JSPromise<JSCryptoKey> generateCryptoKey(
     JSAny algorithm,
     bool extractable,
     JSArray<JSString> keyUsages,
@@ -121,7 +121,7 @@ extension type JSSubtleCrypto(JSObject _) implements JSObject {
 
   /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/generateKey
   @JS('generateKey')
-  external JSPromise<JSCryptoKeyPair> generateCreptoKeyPair(
+  external JSPromise<JSCryptoKeyPair> generateCryptoKeyPair(
     JSAny algorithm,
     bool extractable,
     JSArray<JSString> keyUsages,
@@ -422,7 +422,7 @@ Future<JSCryptoKey> generateKey(
   List<String> usages,
 ) async {
   final value = await window.crypto.subtle
-      .generateCreptoKey(
+      .generateCryptoKey(
         algorithm.toJS,
         extractable,
         usages.toJS,
@@ -438,7 +438,7 @@ Future<JSCryptoKeyPair> generateKeyPair(
   List<String> usages,
 ) async {
   final value = await window.crypto.subtle
-      .generateCreptoKeyPair(
+      .generateCryptoKeyPair(
         algorithm.toJS,
         extractable,
         usages.toJS,

--- a/lib/src/crypto_subtle.dart
+++ b/lib/src/crypto_subtle.dart
@@ -19,6 +19,8 @@ library common;
 import 'dart:js_interop';
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
+
 import 'jsonwebkey.dart' show JsonWebKey, RsaOtherPrimesInfo;
 
 export 'jsonwebkey.dart' show JsonWebKey;
@@ -554,15 +556,17 @@ Future<ByteBuffer> deriveBits(
   return value.toDart;
 }
 
-extension on List<String> {
+extension ListExtension on List<String> {
+  @visibleForTesting
   JSArray<JSString> get toJS => <JSString>[
         for (final value in this) value.toJS,
       ].toJS;
 }
 
-extension on Algorithm {
+extension AlgorithmExtension on Algorithm {
   /// Create JSON from [Algorithm].
   /// To avoid null properties for keys, eliminate keys whose value is null.
+  @visibleForTesting
   JSAny get toJS {
     final json = <String, Object>{};
     final name_ = name;

--- a/lib/src/crypto_subtle.dart
+++ b/lib/src/crypto_subtle.dart
@@ -171,11 +171,12 @@ extension type JSCryptoKey(JSObject _) implements JSObject {
   ///  * `'private'`
   ///  * `'public'`
   ///  * `'secret'`
+  ///
   /// https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey/type
   external String get type;
 
   /// True, if this key can be extracted.
-
+  ///
   /// https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey/extractable
   external bool get extractable;
 
@@ -188,6 +189,7 @@ extension type JSCryptoKey(JSObject _) implements JSObject {
   ///  * `'deriveBits'`,
   ///  * `'wrapKey'`,
   ///  * `'unwrapKey'`.
+  ///
   /// https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey/usages
   external JSArray<JSString> get usages;
 }

--- a/lib/src/crypto_subtle.dart
+++ b/lib/src/crypto_subtle.dart
@@ -332,23 +332,23 @@ extension type JSRsaOtherPrimesInfo(JSObject _) implements JSObject {
 
 TypedData getRandomValues(TypedData array) {
   if (array is Uint8List) {
-    final result = window.crypto.getRandomValues(array.toJS) as JSUint8Array;
-    return result.toDart;
+    window.crypto.getRandomValues(array.toJS);
+    return array;
   } else if (array is Uint16List) {
-    final result = window.crypto.getRandomValues(array.toJS) as JSUint16Array;
-    return result.toDart;
+    window.crypto.getRandomValues(array.toJS);
+    return array;
   } else if (array is Uint32List) {
-    final result = window.crypto.getRandomValues(array.toJS) as JSUint32Array;
-    return result.toDart;
+    window.crypto.getRandomValues(array.toJS);
+    return array;
   } else if (array is Int8List) {
-    final result = window.crypto.getRandomValues(array.toJS) as JSInt8Array;
-    return result.toDart;
+    window.crypto.getRandomValues(array.toJS);
+    return array;
   } else if (array is Int16List) {
-    final result = window.crypto.getRandomValues(array.toJS) as JSInt16Array;
-    return result.toDart;
+    window.crypto.getRandomValues(array.toJS);
+    return array;
   } else if (array is Int32List) {
-    final result = window.crypto.getRandomValues(array.toJS) as JSInt32Array;
-    return result.toDart;
+    window.crypto.getRandomValues(array.toJS);
+    return array;
   } else {
     throw ArgumentError.value(
       array,

--- a/lib/src/crypto_subtle.dart
+++ b/lib/src/crypto_subtle.dart
@@ -16,43 +16,12 @@
 /// browsers `window.crypto.subtle` APIs.
 library common;
 
-import 'dart:async';
-import 'package:js/js_util.dart';
+import 'dart:js_interop';
 import 'dart:typed_data';
-import 'dart:html' show window;
+
 import 'jsonwebkey.dart' show JsonWebKey, RsaOtherPrimesInfo;
+
 export 'jsonwebkey.dart' show JsonWebKey;
-
-/// Constructor for a Javascript `Array`.
-final _array = getProperty(window, 'Array');
-
-/// The `window.crypto` object.
-final _crypto = getProperty(window, 'crypto');
-
-/// The `window.crypto.subtle` object.
-final _subtle = getProperty(_crypto, 'subtle');
-
-/// Call [fn] with property [name] from [jsObj], if present.
-void _getPropertyIfPresent<T>(Object jsObj, String name, void Function(T) fn) {
-  if (hasProperty(jsObj, name)) {
-    fn(getProperty(jsObj, name));
-  }
-}
-
-/// Get property [name] from [jsObj], returns `null` if not present.
-T? _getPropertyOrNull<T>(Object jsObj, String name) {
-  if (hasProperty(jsObj, name)) {
-    return getProperty(jsObj, name);
-  }
-  return null;
-}
-
-/// Set property [name] on [jsObj] if [valie] is not `null`.
-void _setPropertyIfPresent<T>(Object jsObj, String name, T? value) {
-  if (value != null) {
-    setProperty(jsObj, name, value);
-  }
-}
 
 /// Convert [BigInt] to [Uint8List] formatted as [BigInteger][1] following
 /// the Web Cryptography specification.
@@ -73,22 +42,142 @@ Uint8List bigIntToUint8ListBigInteger(BigInt integer) {
   throw UnimplementedError('Only supports 65537 and 3 for now');
 }
 
+/// The `window` object.
+@JS()
+external JSWindow get window;
+
+/// https://developer.mozilla.org/en-US/docs/Web/API/Window
+extension type JSWindow(JSObject _) implements JSObject {
+  /// https://developer.mozilla.org/en-US/docs/Web/API/crypto_property
+  external JSCrypto get crypto;
+}
+
+/// The `window.crypto` object.
+///
+/// https://www.w3.org/TR/WebCryptoAPI/#crypto-interface
+/// https://developer.mozilla.org/en-US/docs/Web/API/Crypto
+extension type JSCrypto(JSObject _) implements JSObject {
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle
+  external JSSubtleCrypto get subtle;
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
+  external JSTypedArray getRandomValues(JSTypedArray array);
+}
+
+/// The `window.crypto.subtle` object.
+///
+/// https://www.w3.org/TR/WebCryptoAPI/#subtlecrypto-interface
+/// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto
+extension type JSSubtleCrypto(JSObject _) implements JSObject {
+  /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt
+  external JSPromise<JSArrayBuffer> encrypt(
+    JSAny algorithm,
+    JSCryptoKey key,
+    JSTypedArray data,
+  );
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/decrypt
+  external JSPromise<JSArrayBuffer> decrypt(
+    JSAny algorithm,
+    JSAny key,
+    JSTypedArray data,
+  );
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/sign
+  external JSPromise<JSArrayBuffer> sign(
+    JSAny algorithm,
+    JSCryptoKey key,
+    JSTypedArray data,
+  );
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/verify
+  external JSPromise<JSBoolean> verify(
+    JSAny algorithm,
+    JSCryptoKey key,
+    JSTypedArray signature,
+    JSTypedArray data,
+  );
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
+  external JSPromise<JSArrayBuffer> digest(
+    String algorithm,
+    JSTypedArray data,
+  );
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/deriveBits
+  external JSPromise<JSArrayBuffer> deriveBits(
+    JSAny algorithm,
+    JSCryptoKey baseKey,
+    int length,
+  );
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/generateKey
+  @JS('generateKey')
+  external JSPromise<JSCryptoKey> generateCreptoKey(
+    JSAny algorithm,
+    bool extractable,
+    JSArray<JSString> keyUsages,
+  );
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/generateKey
+  @JS('generateKey')
+  external JSPromise<JSCryptoKeyPair> generateCreptoKeyPair(
+    JSAny algorithm,
+    bool extractable,
+    JSArray<JSString> keyUsages,
+  );
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey
+  @JS('importKey')
+  external JSPromise<JSCryptoKey> importKey(
+    String format,
+    JSTypedArray keyData,
+    JSAny algorithm,
+    bool extractable,
+    JSArray<JSString> keyUsages,
+  );
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey
+  @JS('importKey')
+  external JSPromise<JSCryptoKey> importJsonWebKey(
+    String format,
+    JSAny keyData,
+    JSAny algorithm,
+    bool extractable,
+    JSArray<JSString> keyUsages,
+  );
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/exportKey
+  @JS('exportKey')
+  external JSPromise<JSArrayBuffer> exportKey(
+    String format,
+    JSCryptoKey key,
+  );
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/exportKey
+  @JS('exportKey')
+  external JSPromise<JSJsonWebKey> exportJsonWebKey(
+    String format,
+    JSCryptoKey key,
+  );
+}
+
 /// Wrapper for the [CryptoKey][1] type.
 ///
 /// [1]: https://www.w3.org/TR/WebCryptoAPI/#cryptokey-interface
-class CryptoKey {
-  final Object _jsObj;
-
-  CryptoKey(this._jsObj);
-
+/// https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey
+extension type JSCryptoKey(JSObject _) implements JSObject {
   /// Returns the _type_ of this key, as one of:
   ///  * `'private'`
   ///  * `'public'`
   ///  * `'secret'`
-  String get type => getProperty(_jsObj, 'type');
+  /// https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey/type
+  external String get type;
 
   /// True, if this key can be extracted.
-  bool get extractable => getProperty(_jsObj, 'extractable');
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey/extractable
+  external bool get extractable;
 
   /// Ways in which this key can be used, list of one or more of:
   ///  * `'encrypt'`,
@@ -99,39 +188,29 @@ class CryptoKey {
   ///  * `'deriveBits'`,
   ///  * `'wrapKey'`,
   ///  * `'unwrapKey'`.
-  List<String> get usages =>
-      _jsArrayToListString(getProperty(_jsObj, 'usages'));
+  /// https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey/usages
+  external JSArray<JSString> get usages;
 }
 
 /// Wrapper for the [CryptoKeyPair][1] type.
 ///
 /// [1]: https://www.w3.org/TR/WebCryptoAPI/#keypair
-class CryptoKeyPair {
-  final Object _jsObj;
-  CryptoKeyPair(this._jsObj);
+/// https://developer.mozilla.org/en-US/docs/Web/API/CryptoKeyPair
+extension type JSCryptoKeyPair(JSObject _) implements JSObject {
+  /// https://developer.mozilla.org/en-US/docs/Web/API/CryptoKeyPair#cryptokeypair.privatekey
+  external JSCryptoKey get privateKey;
 
-  CryptoKey get privateKey => CryptoKey(getProperty(_jsObj, 'privateKey'));
-  CryptoKey get publicKey => CryptoKey(getProperty(_jsObj, 'publicKey'));
+  /// https://developer.mozilla.org/en-US/docs/Web/API/CryptoKeyPair#cryptokeypair.publickey
+  external JSCryptoKey get publicKey;
 }
 
 /// Wrapper for the [DOMException][1] type.
 ///
 /// [1]: https://webidl.spec.whatwg.org/#idl-DOMException
-class DomException implements Exception {
-  final Object _jsObj;
-  DomException.wrap(this._jsObj);
-
-  String get name => getProperty(_jsObj, 'name');
-  String get message => getProperty(_jsObj, 'message');
-}
-
-/// Wrap any error thrown in [fn] as [DomException].
-Future<T> _wrapDomException<T>(Future<T> Function() fn) async {
-  try {
-    return await fn();
-  } catch (e) {
-    throw DomException.wrap(e);
-  }
+@JS('DOMException')
+extension type JSDomException(JSObject _) implements JSObject {
+  external String get name;
+  external String get message;
 }
 
 /// Anonymous object to be used for constructing the `algorithm` parameter in
@@ -147,65 +226,41 @@ Future<T> _wrapDomException<T>(Future<T> Function() fn) async {
 ///
 /// [1]: https://www.w3.org/TR/WebIDL-1/#es-dictionary
 class Algorithm {
-  final Object _jsObj;
+  const Algorithm({
+    this.name,
+    this.modulusLength,
+    this.publicExponent,
+    this.hash,
+    this.saltLength,
+    this.label,
+    this.namedCurve,
+    this.public,
+    this.counter,
+    this.length,
+    this.iv,
+    this.additionalData,
+    this.tagLength,
+    this.salt,
+    this.info,
+    this.iterations,
+  });
 
-  String? get name => _getPropertyOrNull(_jsObj, 'name');
-  int? get modulusLength => _getPropertyOrNull(_jsObj, 'modulusLength');
-  Uint8List? get publicExponent => _getPropertyOrNull(_jsObj, 'publicExponent');
-  String? get hash => _getPropertyOrNull(_jsObj, 'hash');
-  int? get saltLength => _getPropertyOrNull(_jsObj, 'saltLength');
-  TypedData? get label => _getPropertyOrNull(_jsObj, 'label');
-  String? get namedCurve => _getPropertyOrNull(_jsObj, 'namedCurve');
-  CryptoKey? get public => hasProperty(_jsObj, 'public')
-      ? CryptoKey(getProperty(_jsObj, 'public'))
-      : null;
-  TypedData? get counter => _getPropertyOrNull(_jsObj, 'counter');
-  int? get length => _getPropertyOrNull(_jsObj, 'length');
-  TypedData? get iv => _getPropertyOrNull(_jsObj, 'iv');
-  TypedData? get additionalData => _getPropertyOrNull(_jsObj, 'additionalData');
-  int? get tagLength => _getPropertyOrNull(_jsObj, 'tagLength');
-  TypedData? get salt => _getPropertyOrNull(_jsObj, 'salt');
-  TypedData? get info => _getPropertyOrNull(_jsObj, 'info');
-  int? get iterations => _getPropertyOrNull(_jsObj, 'iterations');
-
-  Algorithm({
-    String? name,
-    int? modulusLength,
-    Uint8List? publicExponent,
-    String? hash,
-    int? saltLength,
-    TypedData? label,
-    String? namedCurve,
-    CryptoKey? public,
-    TypedData? counter,
-    int? length,
-    TypedData? iv,
-    TypedData? additionalData,
-    int? tagLength,
-    TypedData? salt,
-    TypedData? info,
-    int? iterations,
-  }) : _jsObj = newObject() {
-    _setPropertyIfPresent(_jsObj, 'name', name);
-    _setPropertyIfPresent(_jsObj, 'name', name);
-    _setPropertyIfPresent(_jsObj, 'modulusLength', modulusLength);
-    _setPropertyIfPresent(_jsObj, 'publicExponent', publicExponent);
-    _setPropertyIfPresent(_jsObj, 'hash', hash);
-    _setPropertyIfPresent(_jsObj, 'saltLength', saltLength);
-    _setPropertyIfPresent(_jsObj, 'label', label);
-    _setPropertyIfPresent(_jsObj, 'namedCurve', namedCurve);
-    if (public != null) {
-      setProperty(_jsObj, 'public', public._jsObj);
-    }
-    _setPropertyIfPresent(_jsObj, 'counter', counter);
-    _setPropertyIfPresent(_jsObj, 'length', length);
-    _setPropertyIfPresent(_jsObj, 'iv', iv);
-    _setPropertyIfPresent(_jsObj, 'additionalData', additionalData);
-    _setPropertyIfPresent(_jsObj, 'tagLength', tagLength);
-    _setPropertyIfPresent(_jsObj, 'salt', salt);
-    _setPropertyIfPresent(_jsObj, 'info', info);
-    _setPropertyIfPresent(_jsObj, 'iterations', iterations);
-  }
+  final String? name;
+  final int? modulusLength;
+  final Uint8List? publicExponent;
+  final String? hash;
+  final int? saltLength;
+  final TypedData? label;
+  final String? namedCurve;
+  final JSCryptoKey? public;
+  final TypedData? counter;
+  final int? length;
+  final TypedData? iv;
+  final TypedData? additionalData;
+  final int? tagLength;
+  final TypedData? salt;
+  final TypedData? info;
+  final int? iterations;
 
   Algorithm update({
     String? name,
@@ -215,7 +270,7 @@ class Algorithm {
     int? saltLength,
     TypedData? label,
     String? namedCurve,
-    CryptoKey? public,
+    JSCryptoKey? public,
     TypedData? counter,
     int? length,
     TypedData? iv,
@@ -245,242 +300,375 @@ class Algorithm {
       );
 }
 
-/// Create [JsonWebKey] from [jsObj].
-JsonWebKey _jsonWebKeyFromJsObj(Object jsObj) {
-  final jwk = JsonWebKey();
-
-  _getPropertyIfPresent(jsObj, 'kty', (String v) => jwk.kty = v);
-  _getPropertyIfPresent(jsObj, 'use', (String v) => jwk.use = v);
-  _getPropertyIfPresent(
-    jsObj,
-    'key_ops',
-    (Object v) => jwk.key_ops = _jsArrayToListString(v),
-  );
-  _getPropertyIfPresent(jsObj, 'alg', (String v) => jwk.alg = v);
-  _getPropertyIfPresent(jsObj, 'ext', (bool v) => jwk.ext = v);
-  _getPropertyIfPresent(jsObj, 'crv', (String v) => jwk.crv = v);
-  _getPropertyIfPresent(jsObj, 'x', (String v) => jwk.x = v);
-  _getPropertyIfPresent(jsObj, 'y', (String v) => jwk.y = v);
-  _getPropertyIfPresent(jsObj, 'd', (String v) => jwk.d = v);
-  _getPropertyIfPresent(jsObj, 'n', (String v) => jwk.n = v);
-  _getPropertyIfPresent(jsObj, 'e', (String v) => jwk.e = v);
-  _getPropertyIfPresent(jsObj, 'p', (String v) => jwk.p = v);
-  _getPropertyIfPresent(jsObj, 'q', (String v) => jwk.q = v);
-  _getPropertyIfPresent(jsObj, 'dp', (String v) => jwk.dp = v);
-  _getPropertyIfPresent(jsObj, 'dq', (String v) => jwk.dq = v);
-  _getPropertyIfPresent(jsObj, 'qi', (String v) => jwk.qi = v);
-  if (hasProperty(jsObj, 'oth')) {
-    final oth = getProperty(jsObj, 'oth');
-    final N = getProperty(oth, 'length');
-    jwk.oth = List.generate(N, (i) {
-      final jsObj = getProperty(oth, i);
-      return RsaOtherPrimesInfo(
-        r: getProperty(jsObj, 'r'),
-        d: getProperty(jsObj, 'd'),
-        t: getProperty(jsObj, 't'),
-      );
-    });
-  }
-  _getPropertyIfPresent(jsObj, 'k', (String v) => jwk.k = v);
-
-  return jwk;
+extension type JSJsonWebKey(JSObject _) implements JSObject {
+  external String? get kty;
+  external String? get use;
+  @JS('key_ops')
+  external JSArray<JSString>? get keyOps;
+  external String? get alg;
+  external bool? get ext;
+  external String? get crv;
+  external String? get x;
+  external String? get y;
+  external String? get d;
+  external String? get n;
+  external String? get e;
+  external String? get p;
+  external String? get q;
+  external String? get dp;
+  external String? get dq;
+  external String? get qi;
+  external JSArray<JSRsaOtherPrimesInfo>? get oth;
+  external String? get k;
 }
 
-/// Convert [JsonWebKey] to a javascript object.
-Object _jsonWebKeyToJsObj(JsonWebKey jwk) {
-  final jsObj = newObject();
-
-  _setPropertyIfPresent(jsObj, 'kty', jwk.kty);
-  _setPropertyIfPresent(jsObj, 'use', jwk.use);
-  _setPropertyIfPresent(jsObj, 'key_ops', jwk.key_ops);
-  _setPropertyIfPresent(jsObj, 'alg', jwk.alg);
-  _setPropertyIfPresent(jsObj, 'ext', jwk.ext);
-  _setPropertyIfPresent(jsObj, 'crv', jwk.crv);
-  _setPropertyIfPresent(jsObj, 'x', jwk.x);
-  _setPropertyIfPresent(jsObj, 'y', jwk.y);
-  _setPropertyIfPresent(jsObj, 'd', jwk.d);
-  _setPropertyIfPresent(jsObj, 'n', jwk.n);
-  _setPropertyIfPresent(jsObj, 'e', jwk.e);
-  _setPropertyIfPresent(jsObj, 'p', jwk.p);
-  _setPropertyIfPresent(jsObj, 'q', jwk.q);
-  _setPropertyIfPresent(jsObj, 'dp', jwk.dp);
-  _setPropertyIfPresent(jsObj, 'dq', jwk.dq);
-  _setPropertyIfPresent(jsObj, 'qi', jwk.qi);
-  final oth = jwk.oth;
-  if (oth != null) {
-    final jsArray = callConstructor(_array, [
-      oth.map((info) {
-        final jsObj = newObject();
-        setProperty(jsObj, 'r', info.r);
-        setProperty(jsObj, 'd', info.d);
-        setProperty(jsObj, 't', info.t);
-        return jsObj;
-      }).toList(),
-    ]);
-    setProperty(jsObj, 'oth', jsArray);
-  }
-  _setPropertyIfPresent(jsObj, 'k', jwk.k);
-
-  return jsObj;
+extension type JSRsaOtherPrimesInfo(JSObject _) implements JSObject {
+  external String get r;
+  external String get d;
+  external String get t;
 }
 
-/// Convert a [list] a Javascript object.
-Object _stringListToJsObj(List<String> list) => callConstructor(
-      _array,
-      list,
+TypedData getRandomValues(TypedData array) {
+  if (array is Uint8List) {
+    final result = window.crypto.getRandomValues(array.toJS) as JSUint8Array;
+    return result.toDart;
+  } else if (array is Uint16List) {
+    final result = window.crypto.getRandomValues(array.toJS) as JSUint16Array;
+    return result.toDart;
+  } else if (array is Uint32List) {
+    final result = window.crypto.getRandomValues(array.toJS) as JSUint32Array;
+    return result.toDart;
+  } else if (array is Int8List) {
+    final result = window.crypto.getRandomValues(array.toJS) as JSInt8Array;
+    return result.toDart;
+  } else if (array is Int16List) {
+    final result = window.crypto.getRandomValues(array.toJS) as JSInt16Array;
+    return result.toDart;
+  } else if (array is Int32List) {
+    final result = window.crypto.getRandomValues(array.toJS) as JSInt32Array;
+    return result.toDart;
+  } else {
+    throw ArgumentError.value(
+      array,
+      'array',
+      'Unsupported TypedData type',
     );
-
-/// Convert [jsArray] to [List<String>].
-List<String> _jsArrayToListString(Object jsArray) {
-  final N = getProperty(jsArray, 'length');
-  return List.generate(N, (i) => getProperty(jsArray, i));
+  }
 }
-
-TypedData getRandomValues(TypedData array) =>
-    callMethod(_crypto, 'getRandomValues', [array]);
 
 Future<ByteBuffer> decrypt(
   Algorithm algorithm,
-  CryptoKey key,
-  TypedData data,
-) =>
-    _wrapDomException(() => promiseToFuture(callMethod(_subtle, 'decrypt', [
-          algorithm._jsObj,
-          key._jsObj,
-          data,
-        ])));
+  JSCryptoKey key,
+  Uint8List data,
+) async {
+  final value = await window.crypto.subtle
+      .decrypt(
+        algorithm.toJS,
+        key,
+        data.toJS,
+      )
+      .toDart;
+
+  return value.toDart;
+}
 
 Future<ByteBuffer> encrypt(
   Algorithm algorithm,
-  CryptoKey key,
-  TypedData data,
-) =>
-    _wrapDomException(() => promiseToFuture(callMethod(_subtle, 'encrypt', [
-          algorithm._jsObj,
-          key._jsObj,
-          data,
-        ])));
+  JSCryptoKey key,
+  Uint8List data,
+) async {
+  final value = await window.crypto.subtle
+      .encrypt(
+        algorithm.toJS,
+        key,
+        data.toJS,
+      )
+      .toDart;
+
+  return value.toDart;
+}
 
 Future<ByteBuffer> exportKey(
   String format,
-  CryptoKey key,
-) =>
-    _wrapDomException(() => promiseToFuture(callMethod(_subtle, 'exportKey', [
-          format,
-          key._jsObj,
-        ])));
+  JSCryptoKey key,
+) async {
+  final value = await window.crypto.subtle
+      .exportKey(
+        format,
+        key,
+      )
+      .toDart;
+
+  return value.toDart;
+}
 
 Future<JsonWebKey> exportJsonWebKey(
   String format,
-  CryptoKey key,
-) async =>
-    _jsonWebKeyFromJsObj(await _wrapDomException(
-      () => promiseToFuture(callMethod(_subtle, 'exportKey', [
+  JSCryptoKey key,
+) async {
+  final value = await window.crypto.subtle
+      .exportJsonWebKey(
         format,
-        key._jsObj,
-      ])),
-    ));
+        key,
+      )
+      .toDart;
 
-Future<CryptoKey> generateKey(
+  return value.toDart;
+}
+
+Future<JSCryptoKey> generateKey(
   Algorithm algorithm,
   bool extractable,
   List<String> usages,
-) async =>
-    CryptoKey(await _wrapDomException(
-      () => promiseToFuture(callMethod(_subtle, 'generateKey', [
-        algorithm._jsObj,
+) async {
+  final value = await window.crypto.subtle
+      .generateCreptoKey(
+        algorithm.toJS,
         extractable,
-        _stringListToJsObj(usages),
-      ])),
-    ));
+        usages.toJS,
+      )
+      .toDart;
 
-Future<CryptoKeyPair> generateKeyPair(
+  return value;
+}
+
+Future<JSCryptoKeyPair> generateKeyPair(
   Algorithm algorithm,
   bool extractable,
   List<String> usages,
-) async =>
-    CryptoKeyPair(await _wrapDomException(
-      () => promiseToFuture(callMethod(_subtle, 'generateKey', [
-        algorithm._jsObj,
+) async {
+  final value = await window.crypto.subtle
+      .generateCreptoKeyPair(
+        algorithm.toJS,
         extractable,
-        _stringListToJsObj(usages),
-      ])),
-    ));
+        usages.toJS,
+      )
+      .toDart;
 
-Future<ByteBuffer> digest(String algorithm, TypedData data) =>
-    _wrapDomException(() => promiseToFuture(callMethod(_subtle, 'digest', [
-          algorithm,
-          data,
-        ])));
+  return value;
+}
 
-Future<CryptoKey> importKey(
+Future<ByteBuffer> digest(
+  String algorithm,
+  Uint8List data,
+) async {
+  final value = await window.crypto.subtle
+      .digest(
+        algorithm,
+        data.toJS,
+      )
+      .toDart;
+
+  return value.toDart;
+}
+
+Future<JSCryptoKey> importKey(
   String format,
-  TypedData keyData,
+  Uint8List keyData,
   Algorithm algorithm,
   bool extractable,
   List<String> usages,
-) async =>
-    CryptoKey(await _wrapDomException(
-      () => promiseToFuture(callMethod(_subtle, 'importKey', [
+) async {
+  final value = await window.crypto.subtle
+      .importKey(
         format,
-        keyData,
-        algorithm._jsObj,
+        keyData.toJS,
+        algorithm.toJS,
         extractable,
-        _stringListToJsObj(usages),
-      ])),
-    ));
+        usages.toJS,
+      )
+      .toDart;
 
-Future<CryptoKey> importJsonWebKey(
+  return value;
+}
+
+Future<JSCryptoKey> importJsonWebKey(
   String format,
   JsonWebKey jwk,
   Algorithm algorithm,
   bool extractable,
   List<String> usages,
-) async =>
-    CryptoKey(await _wrapDomException(
-      () => promiseToFuture(callMethod(_subtle, 'importKey', [
+) async {
+  final value = await window.crypto.subtle
+      .importJsonWebKey(
         format,
-        _jsonWebKeyToJsObj(jwk),
-        algorithm._jsObj,
+        jwk.toJS,
+        algorithm.toJS,
         extractable,
-        _stringListToJsObj(usages),
-      ])),
-    ));
+        usages.toJS,
+      )
+      .toDart;
+
+  return value;
+}
 
 Future<ByteBuffer> sign(
   Algorithm algorithm,
-  CryptoKey key,
-  TypedData data,
-) =>
-    _wrapDomException(() => promiseToFuture(callMethod(_subtle, 'sign', [
-          algorithm._jsObj,
-          key._jsObj,
-          data,
-        ])));
+  JSCryptoKey key,
+  Uint8List data,
+) async {
+  final value = await window.crypto.subtle
+      .sign(
+        algorithm.toJS,
+        key,
+        data.toJS,
+      )
+      .toDart;
+
+  return value.toDart;
+}
 
 Future<bool> verify(
   Algorithm algorithm,
-  CryptoKey key,
-  TypedData signature,
-  TypedData data,
-) =>
-    _wrapDomException(() => promiseToFuture(callMethod(_subtle, 'verify', [
-          algorithm._jsObj,
-          key._jsObj,
-          signature,
-          data,
-        ])));
+  JSCryptoKey key,
+  Uint8List signature,
+  Uint8List data,
+) async {
+  final value = await window.crypto.subtle
+      .verify(
+        algorithm.toJS,
+        key,
+        signature.toJS,
+        data.toJS,
+      )
+      .toDart;
+
+  return value.toDart;
+}
 
 Future<ByteBuffer> deriveBits(
   Algorithm algorithm,
-  CryptoKey key,
+  JSCryptoKey key,
   int length,
-) =>
-    _wrapDomException(() => promiseToFuture(callMethod(_subtle, 'deriveBits', [
-          algorithm._jsObj,
-          key._jsObj,
-          length,
-        ])));
+) async {
+  final value = await window.crypto.subtle
+      .deriveBits(
+        algorithm.toJS,
+        key,
+        length,
+      )
+      .toDart;
+
+  return value.toDart;
+}
+
+extension on List<String> {
+  JSArray<JSString> get toJS => <JSString>[
+        for (final value in this) value.toJS,
+      ].toJS;
+}
+
+extension on Algorithm {
+  /// Create JSON from [Algorithm].
+  /// To avoid null properties for keys, eliminate keys whose value is null.
+  JSAny get toJS {
+    final json = <String, Object>{};
+    final name_ = name;
+    if (name_ != null) {
+      json['name'] = name_;
+    }
+    final modulusLength_ = modulusLength;
+    if (modulusLength_ != null) {
+      json['modulusLength'] = modulusLength_;
+    }
+    final publicExponent_ = publicExponent;
+    if (publicExponent_ != null) {
+      json['publicExponent'] = publicExponent_;
+    }
+    final hash_ = hash;
+    if (hash_ != null) {
+      json['hash'] = hash_;
+    }
+    final saltLength_ = saltLength;
+    if (saltLength_ != null) {
+      json['saltLength'] = saltLength_;
+    }
+    final label_ = label;
+    if (label_ != null) {
+      json['label'] = label_.buffer;
+    }
+    final namedCurve_ = namedCurve;
+    if (namedCurve_ != null) {
+      json['namedCurve'] = namedCurve_;
+    }
+    final public_ = public;
+    if (public_ != null) {
+      json['public'] = public_;
+    }
+    final counter_ = counter;
+    if (counter_ != null) {
+      json['counter'] = counter_;
+    }
+    final length_ = length;
+    if (length_ != null) {
+      json['length'] = length_;
+    }
+    final iv_ = iv;
+    if (iv_ != null) {
+      json['iv'] = iv_.buffer;
+    }
+    final additionalData_ = additionalData;
+    if (additionalData_ != null) {
+      json['additionalData'] = additionalData_.buffer;
+    }
+    final tagLength_ = tagLength;
+    if (tagLength_ != null) {
+      json['tagLength'] = tagLength_;
+    }
+    final salt_ = salt;
+    if (salt_ != null) {
+      json['salt'] = salt_.buffer;
+    }
+    final info_ = info;
+    if (info_ != null) {
+      json['info'] = info_.buffer;
+    }
+    final iterations_ = iterations;
+    if (iterations_ != null) {
+      json['iterations'] = iterations_;
+    }
+
+    return json.jsify()!;
+  }
+}
+
+extension on JsonWebKey {
+  /// Create JSON from [JsonWebKey].
+  /// Convert the map created by JsonWebKey.toJson(),
+  /// to avoid null properties for keys.
+  JSAny get toJS => toJson().jsify()!;
+}
+
+extension on JSJsonWebKey {
+  JsonWebKey get toDart => JsonWebKey(
+        kty: kty,
+        use: use,
+        key_ops: keyOps?.toDart.map((e) => e.toDart).toList(),
+        alg: alg,
+        ext: ext,
+        crv: crv,
+        x: x,
+        y: y,
+        d: d,
+        n: n,
+        e: e,
+        p: p,
+        q: q,
+        dp: dp,
+        dq: dq,
+        qi: qi,
+        oth: oth?.toDart
+            .map(
+              (e) => RsaOtherPrimesInfo(
+                r: e.r,
+                d: e.d,
+                t: e.t,
+              ),
+            )
+            .toList(),
+        k: k,
+      );
+}
 
 // TODO: crypto.subtle.unwrapKey
 // TODO: crypto.subtle.wrapKey

--- a/lib/src/impl_js/impl_js.aescbc.dart
+++ b/lib/src/impl_js/impl_js.aescbc.dart
@@ -48,7 +48,7 @@ Future<AesCbcSecretKey> aesCbc_generateKey(int length) async {
 }
 
 class _AesCbcSecretKey implements AesCbcSecretKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _AesCbcSecretKey(this._key);
 
   @override

--- a/lib/src/impl_js/impl_js.aescbc.dart
+++ b/lib/src/impl_js/impl_js.aescbc.dart
@@ -16,7 +16,7 @@
 
 part of impl_js;
 
-final _aesCbcAlgorithm = subtle.Algorithm(name: 'AES-CBC');
+const _aesCbcAlgorithm = subtle.Algorithm(name: 'AES-CBC');
 
 Future<AesCbcSecretKey> aesCbc_importRawKey(List<int> keyData) async {
   return _AesCbcSecretKey(await _importKey(

--- a/lib/src/impl_js/impl_js.aesctr.dart
+++ b/lib/src/impl_js/impl_js.aesctr.dart
@@ -48,7 +48,7 @@ Future<AesCtrSecretKey> aesCtr_generateKey(int length) async {
 }
 
 class _AesCtrSecretKey implements AesCtrSecretKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _AesCtrSecretKey(this._key);
 
   @override

--- a/lib/src/impl_js/impl_js.aesctr.dart
+++ b/lib/src/impl_js/impl_js.aesctr.dart
@@ -16,7 +16,7 @@
 
 part of impl_js;
 
-final _aesCtrAlgorithm = subtle.Algorithm(name: 'AES-CTR');
+const _aesCtrAlgorithm = subtle.Algorithm(name: 'AES-CTR');
 
 Future<AesCtrSecretKey> aesCtr_importRawKey(List<int> keyData) async {
   return _AesCtrSecretKey(await _importKey(

--- a/lib/src/impl_js/impl_js.aesgcm.dart
+++ b/lib/src/impl_js/impl_js.aesgcm.dart
@@ -48,7 +48,7 @@ Future<AesGcmSecretKey> aesGcm_generateKey(int length) async {
 }
 
 class _AesGcmSecretKey implements AesGcmSecretKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _AesGcmSecretKey(this._key);
 
   @override

--- a/lib/src/impl_js/impl_js.aesgcm.dart
+++ b/lib/src/impl_js/impl_js.aesgcm.dart
@@ -16,7 +16,7 @@
 
 part of impl_js;
 
-final _aesGcmAlgorithm = subtle.Algorithm(name: 'AES-GCM');
+const _aesGcmAlgorithm = subtle.Algorithm(name: 'AES-GCM');
 
 Future<AesGcmSecretKey> aesGcm_importRawKey(List<int> keyData) async {
   return _AesGcmSecretKey(await _importKey(

--- a/lib/src/impl_js/impl_js.ecdh.dart
+++ b/lib/src/impl_js/impl_js.ecdh.dart
@@ -125,7 +125,7 @@ Future<EcdhPublicKey> ecdhPublicKey_importJsonWebKey(
 }
 
 class _EcdhPrivateKey implements EcdhPrivateKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _EcdhPrivateKey(this._key);
 
   @override
@@ -172,7 +172,7 @@ class _EcdhPrivateKey implements EcdhPrivateKey {
 }
 
 class _EcdhPublicKey implements EcdhPublicKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _EcdhPublicKey(this._key);
 
   @override

--- a/lib/src/impl_js/impl_js.ecdsa.dart
+++ b/lib/src/impl_js/impl_js.ecdsa.dart
@@ -113,7 +113,7 @@ Future<EcdsaPublicKey> ecdsaPublicKey_importJsonWebKey(
 }
 
 class _EcdsaPrivateKey implements EcdsaPrivateKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _EcdsaPrivateKey(this._key);
 
   @override
@@ -145,7 +145,7 @@ class _EcdsaPrivateKey implements EcdsaPrivateKey {
 }
 
 class _EcdsaPublicKey implements EcdsaPublicKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _EcdsaPublicKey(this._key);
 
   @override

--- a/lib/src/impl_js/impl_js.hkdf.dart
+++ b/lib/src/impl_js/impl_js.hkdf.dart
@@ -22,7 +22,7 @@ Future<HkdfSecretKey> hkdfSecretKey_importRawKey(List<int> keyData) async {
   return _HkdfSecretKey(await _importKey(
     'raw',
     keyData,
-    subtle.Algorithm(name: _hkdfAlgorithmName),
+    const subtle.Algorithm(name: _hkdfAlgorithmName),
     _usagesDeriveBits,
     'secret',
     // Unlike all other key types it makes no sense to HkdfSecretKey to be

--- a/lib/src/impl_js/impl_js.hkdf.dart
+++ b/lib/src/impl_js/impl_js.hkdf.dart
@@ -32,7 +32,7 @@ Future<HkdfSecretKey> hkdfSecretKey_importRawKey(List<int> keyData) async {
 }
 
 class _HkdfSecretKey implements HkdfSecretKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _HkdfSecretKey(this._key);
 
   @override

--- a/lib/src/impl_js/impl_js.hmac.dart
+++ b/lib/src/impl_js/impl_js.hmac.dart
@@ -82,7 +82,7 @@ Future<HmacSecretKey> hmacSecretKey_generateKey(Hash hash,
 }
 
 class _HmacSecretKey implements HmacSecretKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _HmacSecretKey(this._key);
 
   @override

--- a/lib/src/impl_js/impl_js.hmac.dart
+++ b/lib/src/impl_js/impl_js.hmac.dart
@@ -16,7 +16,7 @@
 
 part of impl_js;
 
-final _hmacAlgorithm = subtle.Algorithm(name: 'HMAC');
+const _hmacAlgorithm = subtle.Algorithm(name: 'HMAC');
 
 Future<HmacSecretKey> hmacSecretKey_importRawKey(
   List<int> keyData,

--- a/lib/src/impl_js/impl_js.pbkdf2.dart
+++ b/lib/src/impl_js/impl_js.pbkdf2.dart
@@ -22,7 +22,7 @@ Future<Pbkdf2SecretKey> pbkdf2SecretKey_importRawKey(List<int> keyData) async {
   return _Pbkdf2SecretKey(await _importKey(
     'raw',
     keyData,
-    subtle.Algorithm(name: _pbkdf2AlgorithmName),
+    const subtle.Algorithm(name: _pbkdf2AlgorithmName),
     _usagesDeriveBits,
     'secret',
     // Unlike all other key types it makes no sense to HkdfSecretKey to be

--- a/lib/src/impl_js/impl_js.pbkdf2.dart
+++ b/lib/src/impl_js/impl_js.pbkdf2.dart
@@ -32,7 +32,7 @@ Future<Pbkdf2SecretKey> pbkdf2SecretKey_importRawKey(List<int> keyData) async {
 }
 
 class _Pbkdf2SecretKey implements Pbkdf2SecretKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _Pbkdf2SecretKey(this._key);
 
   @override

--- a/lib/src/impl_js/impl_js.random.dart
+++ b/lib/src/impl_js/impl_js.random.dart
@@ -17,7 +17,7 @@ part of impl_js;
 void fillRandomBytes(TypedData destination) {
   try {
     subtle.getRandomValues(destination);
-  } on subtle.DomException catch (e) {
+  } on subtle.JSDomException catch (e) {
     throw _translateDomException(e);
   }
 }

--- a/lib/src/impl_js/impl_js.rsaoaep.dart
+++ b/lib/src/impl_js/impl_js.rsaoaep.dart
@@ -102,7 +102,7 @@ Future<RsaOaepPublicKey> rsaOaepPublicKey_importJsonWebKey(
 }
 
 class _RsaOaepPrivateKey implements RsaOaepPrivateKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _RsaOaepPrivateKey(this._key);
 
   @override
@@ -131,7 +131,7 @@ class _RsaOaepPrivateKey implements RsaOaepPrivateKey {
 }
 
 class _RsaOaepPublicKey implements RsaOaepPublicKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _RsaOaepPublicKey(this._key);
 
   @override

--- a/lib/src/impl_js/impl_js.rsaoaep.dart
+++ b/lib/src/impl_js/impl_js.rsaoaep.dart
@@ -109,7 +109,7 @@ class _RsaOaepPrivateKey implements RsaOaepPrivateKey {
   Future<Uint8List> decryptBytes(List<int> data, {List<int>? label}) async {
     return _decrypt(
       label == null
-          ? subtle.Algorithm(name: _rsaOaepAlgorithmName)
+          ? const subtle.Algorithm(name: _rsaOaepAlgorithmName)
           : subtle.Algorithm(
               name: _rsaOaepAlgorithmName,
               label: Uint8List.fromList(label),
@@ -138,7 +138,7 @@ class _RsaOaepPublicKey implements RsaOaepPublicKey {
   Future<Uint8List> encryptBytes(List<int> data, {List<int>? label}) async {
     return _encrypt(
       label == null
-          ? subtle.Algorithm(name: _rsaOaepAlgorithmName)
+          ? const subtle.Algorithm(name: _rsaOaepAlgorithmName)
           : subtle.Algorithm(
               name: _rsaOaepAlgorithmName,
               label: Uint8List.fromList(label),

--- a/lib/src/impl_js/impl_js.rsapss.dart
+++ b/lib/src/impl_js/impl_js.rsapss.dart
@@ -89,7 +89,7 @@ Future<RsaPssPublicKey> rsaPssPublicKey_importJsonWebKey(
 }
 
 class _RsaPssPrivateKey implements RsaPssPrivateKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _RsaPssPrivateKey(this._key);
 
   @override
@@ -126,7 +126,7 @@ class _RsaPssPrivateKey implements RsaPssPrivateKey {
 }
 
 class _RsaPssPublicKey implements RsaPssPublicKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _RsaPssPublicKey(this._key);
 
   @override

--- a/lib/src/impl_js/impl_js.rsassapkcs1v15.dart
+++ b/lib/src/impl_js/impl_js.rsassapkcs1v15.dart
@@ -16,7 +16,7 @@
 
 part of impl_js;
 
-final _rsassaPkcs1V15Algorithm = subtle.Algorithm(name: 'RSASSA-PKCS1-v1_5');
+const _rsassaPkcs1V15Algorithm = subtle.Algorithm(name: 'RSASSA-PKCS1-v1_5');
 
 Future<RsassaPkcs1V15PrivateKey> rsassaPkcs1V15PrivateKey_importPkcs8Key(
   List<int> keyData,

--- a/lib/src/impl_js/impl_js.rsassapkcs1v15.dart
+++ b/lib/src/impl_js/impl_js.rsassapkcs1v15.dart
@@ -89,7 +89,7 @@ Future<RsassaPkcs1V15PublicKey> rsassaPkcs1V15PublicKey_importJsonWebKey(
 }
 
 class _RsassaPkcs1V15PrivateKey implements RsassaPkcs1V15PrivateKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _RsassaPkcs1V15PrivateKey(this._key);
 
   @override
@@ -114,7 +114,7 @@ class _RsassaPkcs1V15PrivateKey implements RsassaPkcs1V15PrivateKey {
 }
 
 class _RsassaPkcs1V15PublicKey implements RsassaPkcs1V15PublicKey {
-  final subtle.CryptoKey _key;
+  final subtle.JSCryptoKey _key;
   _RsassaPkcs1V15PublicKey(this._key);
 
   @override

--- a/lib/src/impl_js/impl_js.utils.dart
+++ b/lib/src/impl_js/impl_js.utils.dart
@@ -50,7 +50,7 @@ String _curveToName(EllipticCurve curve) {
 }
 
 Object _translateDomException(
-  subtle.DomException e, {
+  subtle.JSDomException e, {
   bool invalidAccessErrorIsArgumentError = false,
 }) {
   var message = e.message;
@@ -97,7 +97,7 @@ Object _translateDomException(
       '"${e.name}", message: $message');
 }
 
-/// Handle instances of [subtle.DomException] specified in the
+/// Handle instances of [subtle.JSDomException] specified in the
 /// [Web Cryptograpy specification][1].
 ///
 /// [1]: https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-Exceptions
@@ -107,7 +107,7 @@ Future<T> _handleDomException<T>(
 }) async {
   try {
     return await fn();
-  } on subtle.DomException catch (e) {
+  } on subtle.JSDomException catch (e) {
     throw _translateDomException(
       e,
       invalidAccessErrorIsArgumentError: invalidAccessErrorIsArgumentError,
@@ -124,7 +124,7 @@ final _usagesEncrypt = ['encrypt'];
 final _usagesDeriveBits = ['deriveBits'];
 
 /// Adapt `crypto.subtle.importKey` to Dart types for JWK.
-Future<subtle.CryptoKey> _importJsonWebKey(
+Future<subtle.JSCryptoKey> _importJsonWebKey(
   Map<String, dynamic> jwk,
   subtle.Algorithm algorithm,
   List<String> usages,
@@ -154,7 +154,7 @@ Future<subtle.CryptoKey> _importJsonWebKey(
 }
 
 /// Adapt `crypto.subtle.importKey` to Dart types.
-Future<subtle.CryptoKey> _importKey(
+Future<subtle.JSCryptoKey> _importKey(
   String format,
   List<int> keyData,
   subtle.Algorithm algorithm,
@@ -181,7 +181,7 @@ Future<subtle.CryptoKey> _importKey(
 /// Adapt `crypto.subtle.sign` to Dart types.
 Future<Uint8List> _sign(
   subtle.Algorithm algorithm,
-  subtle.CryptoKey key,
+  subtle.JSCryptoKey key,
   List<int> data,
 ) {
   return _handleDomException(() async {
@@ -197,7 +197,7 @@ Future<Uint8List> _sign(
 /// Adapt `crypto.subtle.verify` to Dart types.
 Future<bool> _verify(
   subtle.Algorithm algorithm,
-  subtle.CryptoKey key,
+  subtle.JSCryptoKey key,
   List<int> signature,
   List<int> data,
 ) {
@@ -214,7 +214,7 @@ Future<bool> _verify(
 /// Adapt `crypto.subtle.encrypt` to Dart types.
 Future<Uint8List> _encrypt(
   subtle.Algorithm algorithm,
-  subtle.CryptoKey key,
+  subtle.JSCryptoKey key,
   List<int> data,
 ) {
   return _handleDomException(() async {
@@ -230,7 +230,7 @@ Future<Uint8List> _encrypt(
 /// Adapt `crypto.subtle.decrypt` to Dart types.
 Future<Uint8List> _decrypt(
   subtle.Algorithm algorithm,
-  subtle.CryptoKey key,
+  subtle.JSCryptoKey key,
   List<int> data,
 ) {
   return _handleDomException(() async {
@@ -246,7 +246,7 @@ Future<Uint8List> _decrypt(
 /// Adapt `crypto.subtle.deriveBits` to Dart types.
 Future<Uint8List> _deriveBits(
   subtle.Algorithm algorithm,
-  subtle.CryptoKey key,
+  subtle.JSCryptoKey key,
   int length, {
   bool invalidAccessErrorIsArgumentError = false,
 }) {
@@ -263,7 +263,7 @@ Future<Uint8List> _deriveBits(
 /// Adapt `crypto.subtle.export` to Dart types.
 Future<Uint8List> _exportKey(
   String format,
-  subtle.CryptoKey key,
+  subtle.JSCryptoKey key,
 ) {
   return _handleDomException(() async {
     final result = await subtle.exportKey(format, key);
@@ -273,7 +273,7 @@ Future<Uint8List> _exportKey(
 
 /// Adapt `crypto.subtle.export` to Dart types.
 Future<Map<String, Object>> _exportJsonWebKey(
-  subtle.CryptoKey key,
+  subtle.JSCryptoKey key,
   // TODO: Add expected 'use' the way we have it in the FFI implementation
 ) {
   return _handleDomException(() async {
@@ -291,7 +291,7 @@ Future<Map<String, Object>> _exportJsonWebKey(
 }
 
 /// Adapt `crypto.subtle.generateKey` to Dart types.
-Future<subtle.CryptoKey> _generateKey(
+Future<subtle.JSCryptoKey> _generateKey(
   subtle.Algorithm algorithm,
   List<String> usages,
   String expectedType,
@@ -308,7 +308,7 @@ Future<subtle.CryptoKey> _generateKey(
 }
 
 /// Adapt `crypto.subtle.generateKey` to Dart types.
-Future<subtle.CryptoKeyPair> _generateKeyPair(
+Future<subtle.JSCryptoKeyPair> _generateKeyPair(
   subtle.Algorithm algorithm,
   List<String> usages,
 ) {

--- a/lib/src/impl_js/impl_js.utils.dart
+++ b/lib/src/impl_js/impl_js.utils.dart
@@ -60,6 +60,8 @@ Object _translateDomException(
   switch (e.name) {
     case 'SyntaxError':
       return ArgumentError(message);
+    case 'TypeError':
+      return ArgumentError(message);
     case 'QuotaExceededError':
       return ArgumentError(message);
     case 'NotSupportedError':

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,6 @@ environment:
 
 dependencies:
   ffi: ^2.0.0
-  js: ^0.6.3
   meta: ^1.3.0
   # Needed for `lib/src/flutter/webcrypto_plugin.dart` which allows boiler-plate
   # in `flutter.plugin.platforms.web` added below.

--- a/test/browser_chrome_test.dart
+++ b/test/browser_chrome_test.dart
@@ -1,0 +1,135 @@
+@TestOn('chrome')
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:webcrypto/src/impl_js/impl_js.dart';
+import 'package:webcrypto/src/crypto_subtle.dart';
+import 'package:webcrypto/src/testing/webcrypto/random.dart';
+
+void main() {
+  group('fillRandomBytes', () {
+    test('Uint8List: success', () {
+      final data = Uint8List(16 * 1024);
+      isAllZero(data);
+      fillRandomBytes(data);
+      isNotAllZero(data);
+    });
+
+    test('Uint8List: too long', () {
+      expect(
+        () => fillRandomBytes(Uint8List(1000000)),
+        throwsA(isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          contains(
+            '''Failed to execute 'getRandomValues' on 'Crypto': The ArrayBufferView's byte length (1000000) exceeds the number of bytes of entropy available via this API (65536).''',
+          ),
+        )),
+      );
+    });
+
+    test('Uint64List: not supported type', () {
+      expect(
+        () => fillRandomBytes(Uint64List(32)),
+        throwsA(
+          isA<UnsupportedError>().having(
+            (e) => e.message,
+            'message',
+            contains(
+              'Uint64List not supported on the web.',
+            ),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('crypto.subtle', () {
+    test('generateCryptoKey: success', () async {
+      final key = await window.crypto.subtle
+          .generateCryptoKey(
+            const Algorithm(
+              name: 'ECDH',
+              namedCurve: 'P-384',
+            ).toJS,
+            false,
+            ['deriveBits'].toJS,
+          )
+          .toDart;
+
+      expect(key, isA<JSCryptoKey>());
+    });
+
+    test('generateCryptoKey: SyntaxError', () async {
+      expect(
+        () async => await window.crypto.subtle
+            .generateCryptoKey(
+              const Algorithm(
+                name: 'ECDH',
+                namedCurve: 'P-384',
+              ).toJS,
+              false,
+              <String>[].toJS,
+            )
+            .toDart,
+        throwsA(
+          isA<JSDomException>()
+              .having(
+                (e) => e.name,
+                'name',
+                'SyntaxError',
+              )
+              .having(
+                (e) => e.message,
+                'message',
+                contains(
+                  '''Usages cannot be empty when creating a key''',
+                ),
+              ),
+        ),
+      );
+    });
+
+    test('generateCryptoKey: TypeError', () async {
+      expect(
+        () async => await window.crypto.subtle
+            .generateCryptoKey(
+              const Algorithm().toJS,
+              false,
+              ['deriveBits'].toJS,
+            )
+            .toDart,
+        throwsA(
+          isA<JSDomException>()
+              .having(
+                (e) => e.name,
+                'name',
+                'TypeError',
+              )
+              .having(
+                (e) => e.message,
+                'message',
+                contains(
+                  '''Failed to execute 'generateKey' on 'SubtleCrypto': Algorithm: name: Missing or not a string''',
+                ),
+              ),
+        ),
+      );
+    });
+  });
+}

--- a/test/browser_chrome_test.dart
+++ b/test/browser_chrome_test.dart
@@ -59,6 +59,57 @@ void main() {
     });
   });
 
+  group('crypto', () {
+    test('getRandomValues: success', () {
+      final data = Uint8List(16 * 1024);
+      isAllZero(data);
+      window.crypto.getRandomValues(data.toJS);
+      isNotAllZero(data);
+    });
+
+    test('getRandomValues: too long', () {
+      expect(
+        () => window.crypto.getRandomValues(Uint8List(1000000).toJS),
+        throwsA(
+          isA<JSDomException>()
+              .having(
+                (e) => e.name,
+                'name',
+                'QuotaExceededError',
+              )
+              .having(
+                (e) => e.message,
+                'message',
+                contains(
+                  '''Failed to execute 'getRandomValues' on 'Crypto': The ArrayBufferView's byte length (1000000) exceeds the number of bytes of entropy available via this API (65536).''',
+                ),
+              ),
+        ),
+      );
+    });
+
+    test('getRandomValues: not supported type', () {
+      expect(
+        () => window.crypto.getRandomValues(Float32List(32).toJS),
+        throwsA(
+          isA<JSDomException>()
+              .having(
+                (e) => e.name,
+                'name',
+                'TypeMismatchError',
+              )
+              .having(
+                (e) => e.message,
+                'message',
+                contains(
+                  '''Failed to execute 'getRandomValues' on 'Crypto': The provided ArrayBufferView is of type 'Float32', which is not an integer array type.''',
+                ),
+              ),
+        ),
+      );
+    });
+  });
+
   group('crypto.subtle', () {
     test('generateCryptoKey: success', () async {
       final key = await window.crypto.subtle

--- a/test/browser_chrome_test.dart
+++ b/test/browser_chrome_test.dart
@@ -75,7 +75,7 @@ void main() {
       expect(key, isA<JSCryptoKey>());
     });
 
-    test('generateCryptoKey: SyntaxError', () async {
+    test('generateCryptoKey: invalid keyUsages: SyntaxError', () async {
       expect(
         () async => await window.crypto.subtle
             .generateCryptoKey(
@@ -105,7 +105,7 @@ void main() {
       );
     });
 
-    test('generateCryptoKey: TypeError', () async {
+    test('generateCryptoKey: invalid algorithm: TypeError', () async {
       expect(
         () async => await window.crypto.subtle
             .generateCryptoKey(

--- a/test/browser_firefox_test.dart
+++ b/test/browser_firefox_test.dart
@@ -75,7 +75,7 @@ void main() {
       expect(key, isA<JSCryptoKey>());
     });
 
-    test('generateCryptoKey: SyntaxError', () async {
+    test('generateCryptoKey: invalid keyUsages: SyntaxError', () async {
       expect(
         () async => await window.crypto.subtle
             .generateCryptoKey(
@@ -105,7 +105,7 @@ void main() {
       );
     });
 
-    test('generateCryptoKey: TypeError', () async {
+    test('generateCryptoKey: invalid algorithm: SyntaxError', () async {
       expect(
         () async => await window.crypto.subtle
             .generateCryptoKey(
@@ -119,7 +119,7 @@ void main() {
               .having(
                 (e) => e.name,
                 'name',
-                'TypeError',
+                'SyntaxError',
               )
               .having(
                 (e) => e.message,

--- a/test/browser_firefox_test.dart
+++ b/test/browser_firefox_test.dart
@@ -59,6 +59,57 @@ void main() {
     });
   });
 
+  group('crypto', () {
+    test('getRandomValues: success', () {
+      final data = Uint8List(16 * 1024);
+      isAllZero(data);
+      window.crypto.getRandomValues(data.toJS);
+      isNotAllZero(data);
+    });
+
+    test('getRandomValues: too long', () {
+      expect(
+        () => window.crypto.getRandomValues(Uint8List(1000000).toJS),
+        throwsA(
+          isA<JSDomException>()
+              .having(
+                (e) => e.name,
+                'name',
+                'QuotaExceededError',
+              )
+              .having(
+                (e) => e.message,
+                'message',
+                contains(
+                  '''Failed to execute 'getRandomValues' on 'Crypto': The ArrayBufferView's byte length (1000000) exceeds the number of bytes of entropy available via this API (65536).''',
+                ),
+              ),
+        ),
+      );
+    });
+
+    test('getRandomValues: not supported type', () {
+      expect(
+        () => window.crypto.getRandomValues(Float32List(32).toJS),
+        throwsA(
+          isA<JSDomException>()
+              .having(
+                (e) => e.name,
+                'name',
+                'TypeMismatchError',
+              )
+              .having(
+                (e) => e.message,
+                'message',
+                contains(
+                  '''Failed to execute 'getRandomValues' on 'Crypto': The provided ArrayBufferView is of type 'Float32', which is not an integer array type.''',
+                ),
+              ),
+        ),
+      );
+    });
+  });
+
   group('crypto.subtle', () {
     test('generateCryptoKey: success', () async {
       final key = await window.crypto.subtle

--- a/test/browser_firefox_test.dart
+++ b/test/browser_firefox_test.dart
@@ -1,4 +1,4 @@
-@TestOn('browser')
+@TestOn('firefox')
 // Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,7 @@ void main() {
           (e) => e.message,
           'message',
           contains(
-            '''Failed to execute 'getRandomValues' on 'Crypto': The ArrayBufferView's byte length (1000000) exceeds the number of bytes of entropy available via this API (65536).''',
+            '''Crypto.getRandomValues: getRandomValues can only generate maximum 65536 bytes''',
           ),
         )),
       );
@@ -98,7 +98,7 @@ void main() {
                 (e) => e.message,
                 'message',
                 contains(
-                  '''Usages cannot be empty when creating a key''',
+                  '''An invalid or illegal string was specified''',
                 ),
               ),
         ),
@@ -125,7 +125,7 @@ void main() {
                 (e) => e.message,
                 'message',
                 contains(
-                  '''Failed to execute 'generateKey' on 'SubtleCrypto': Algorithm: name: Missing or not a string''',
+                  '''An invalid or illegal string was specified''',
                 ),
               ),
         ),

--- a/test/browser_firefox_test.dart
+++ b/test/browser_firefox_test.dart
@@ -81,7 +81,7 @@ void main() {
                 (e) => e.message,
                 'message',
                 contains(
-                  '''Failed to execute 'getRandomValues' on 'Crypto': The ArrayBufferView's byte length (1000000) exceeds the number of bytes of entropy available via this API (65536).''',
+                  '''Crypto.getRandomValues: getRandomValues can only generate maximum 65536 bytes''',
                 ),
               ),
         ),
@@ -102,7 +102,7 @@ void main() {
                 (e) => e.message,
                 'message',
                 contains(
-                  '''Failed to execute 'getRandomValues' on 'Crypto': The provided ArrayBufferView is of type 'Float32', which is not an integer array type.''',
+                  '''The type of an object is incompatible with the expected type of the parameter associated to the object''',
                 ),
               ),
         ),

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -1,0 +1,135 @@
+@TestOn('browser')
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:webcrypto/src/impl_js/impl_js.dart';
+import 'package:webcrypto/src/crypto_subtle.dart';
+import 'package:webcrypto/src/testing/webcrypto/random.dart';
+
+void main() {
+  group('fillRandomBytes', () {
+    test('Uint8List: success', () {
+      final data = Uint8List(16 * 1024);
+      isAllZero(data);
+      fillRandomBytes(data);
+      isNotAllZero(data);
+    });
+
+    test('Uint8List: too long', () {
+      expect(
+        () => fillRandomBytes(Uint8List(1000000)),
+        throwsA(isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          contains(
+            '''Failed to execute 'getRandomValues' on 'Crypto': The ArrayBufferView's byte length (1000000) exceeds the number of bytes of entropy available via this API (65536).''',
+          ),
+        )),
+      );
+    });
+
+    test('Uint64List: not supported type', () {
+      expect(
+        () => fillRandomBytes(Uint64List(32)),
+        throwsA(
+          isA<UnsupportedError>().having(
+            (e) => e.message,
+            'message',
+            contains(
+              'Uint64List not supported on the web.',
+            ),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('crypto.subtle', () {
+    test('generateCryptoKey: success', () async {
+      final key = await window.crypto.subtle
+          .generateCryptoKey(
+            const Algorithm(
+              name: 'ECDH',
+              namedCurve: 'P-384',
+            ).toJS,
+            false,
+            ['deriveBits'].toJS,
+          )
+          .toDart;
+
+      expect(key, isA<JSCryptoKey>());
+    });
+
+    test('generateCryptoKey: SyntaxError', () async {
+      expect(
+        () async => await window.crypto.subtle
+            .generateCryptoKey(
+              const Algorithm(
+                name: 'ECDH',
+                namedCurve: 'P-384',
+              ).toJS,
+              false,
+              <String>[].toJS,
+            )
+            .toDart,
+        throwsA(
+          isA<JSDomException>()
+              .having(
+                (e) => e.name,
+                'name',
+                'SyntaxError',
+              )
+              .having(
+                (e) => e.message,
+                'message',
+                contains(
+                  '''Usages cannot be empty when creating a key''',
+                ),
+              ),
+        ),
+      );
+    });
+
+    test('generateCryptoKey: TypeError', () async {
+      expect(
+        () async => await window.crypto.subtle
+            .generateCryptoKey(
+              const Algorithm().toJS,
+              false,
+              ['deriveBits'].toJS,
+            )
+            .toDart,
+        throwsA(
+          isA<JSDomException>()
+              .having(
+                (e) => e.name,
+                'name',
+                'TypeError',
+              )
+              .having(
+                (e) => e.message,
+                'message',
+                contains(
+                  '''Failed to execute 'generateKey' on 'SubtleCrypto': Algorithm: name: Missing or not a string''',
+                ),
+              ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Migrate web crypto api  code to `dart:js_interop`.

I have added `JS` to class names, like `JSWindow`, to distinguish it from classes that are not related to `dart:js_interop`. But if this is unnecessary, please point it out in review comments.

close #83
