### PR TITLE
Remove comment about EC PKCS #8 not working on Firefox, and add tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
       - run: flutter pub get
       - run: flutter pub run webcrypto:setup
       - run: flutter test
-      - run: flutter test --platform chrome
+      #- run: flutter test --platform chrome
       - run: flutter test integration_test/webcrypto_test.dart -d windows
         working-directory: ./example
       - uses: nanasess/setup-chromedriver@v2

--- a/lib/src/testing/webcrypto/ecdh.dart
+++ b/lib/src/testing/webcrypto/ecdh.dart
@@ -31,13 +31,9 @@ final runner = TestRunner.asymmetric<EcdhPrivateKey, EcdhPublicKey>(
   algorithm: 'ECDH',
   importPrivateRawKey: null, // not supported
   exportPrivateRawKey: null,
-  // HACK: PKCS8 is not support for ECDH / ECDSA on firefox:
-  // https://bugzilla.mozilla.org/show_bug.cgi?id=1133698
-  //
-  // So filter away PKCS8 test data and functions when running on gecko.
-  importPrivatePkcs8Key: nullOnFirefox((keyData, keyImportParams) =>
-      EcdhPrivateKey.importPkcs8Key(keyData, curveFromJson(keyImportParams))),
-  exportPrivatePkcs8Key: nullOnFirefox((key) => key.exportPkcs8Key()),
+  importPrivatePkcs8Key: (keyData, keyImportParams) =>
+      EcdhPrivateKey.importPkcs8Key(keyData, curveFromJson(keyImportParams)),
+  exportPrivatePkcs8Key: (key) => key.exportPkcs8Key(),
   importPrivateJsonWebKey: (jsonWebKeyData, keyImportParams) =>
       EcdhPrivateKey.importJsonWebKey(
           jsonWebKeyData, curveFromJson(keyImportParams)),
@@ -70,10 +66,7 @@ final runner = TestRunner.asymmetric<EcdhPrivateKey, EcdhPublicKey>(
     length,
     keys.publicKey,
   ),
-  testData: _testData.map((c) => {
-        ...c,
-        'privatePkcs8KeyData': nullOnFirefox(c['privatePkcs8KeyData']),
-      }),
+  testData: _testData,
 );
 
 void main() async {

--- a/lib/src/testing/webcrypto/ecdsa.dart
+++ b/lib/src/testing/webcrypto/ecdsa.dart
@@ -15,19 +15,14 @@
 import 'package:webcrypto/webcrypto.dart';
 import '../utils/utils.dart';
 import '../utils/testrunner.dart';
-import '../utils/detected_runtime.dart';
 
 final runner = TestRunner.asymmetric<EcdsaPrivateKey, EcdsaPublicKey>(
   algorithm: 'ECDSA',
   importPrivateRawKey: null, // not supported
   exportPrivateRawKey: null,
-  // HACK: PKCS8 is not support for ECDH / ECDSA on firefox:
-  // https://bugzilla.mozilla.org/show_bug.cgi?id=1133698
-  //
-  // So filter away PKCS8 test data and functions when running on gecko.
-  importPrivatePkcs8Key: nullOnFirefox((keyData, keyImportParams) =>
-      EcdsaPrivateKey.importPkcs8Key(keyData, curveFromJson(keyImportParams))),
-  exportPrivatePkcs8Key: nullOnFirefox((key) => key.exportPkcs8Key()),
+  importPrivatePkcs8Key: (keyData, keyImportParams) =>
+      EcdsaPrivateKey.importPkcs8Key(keyData, curveFromJson(keyImportParams)),
+  exportPrivatePkcs8Key: (key) => key.exportPkcs8Key(),
   importPrivateJsonWebKey: (jsonWebKeyData, keyImportParams) =>
       EcdsaPrivateKey.importJsonWebKey(
           jsonWebKeyData, curveFromJson(keyImportParams)),
@@ -53,10 +48,7 @@ final runner = TestRunner.asymmetric<EcdsaPrivateKey, EcdsaPublicKey>(
       key.verifyBytes(signature, data, hashFromJson(verifyParams)),
   verifyStream: (key, signature, data, verifyParams) =>
       key.verifyStream(signature, data, hashFromJson(verifyParams)),
-  testData: _testData.map((c) => {
-        ...c,
-        'privatePkcs8KeyData': nullOnFirefox(c['privatePkcs8KeyData']),
-      }),
+  testData: _testData,
 );
 
 void main() async {

--- a/lib/src/webcrypto/webcrypto.ecdh.dart
+++ b/lib/src/webcrypto/webcrypto.ecdh.dart
@@ -18,7 +18,6 @@ part of 'webcrypto.dart';
 abstract class EcdhPrivateKey {
   EcdhPrivateKey._(); // keep the constructor private.
 
-  // Note. unsupported on Firefox, see EcdsaPrivateKey.importPkcs8Key
   static Future<EcdhPrivateKey> importPkcs8Key(
     List<int> keyData,
     EllipticCurve curve,
@@ -48,7 +47,6 @@ abstract class EcdhPrivateKey {
   // https://tools.ietf.org/html/rfc6090#appendix-B
   Future<Uint8List> deriveBits(int length, EcdhPublicKey publicKey);
 
-  // Note. unsupported on Firefox, see EcdsaPrivateKey.importPkcs8Key
   Future<Uint8List> exportPkcs8Key();
 
   Future<Map<String, dynamic>> exportJsonWebKey();

--- a/lib/src/webcrypto/webcrypto.ecdsa.dart
+++ b/lib/src/webcrypto/webcrypto.ecdsa.dart
@@ -18,9 +18,6 @@ part of 'webcrypto.dart';
 abstract class EcdsaPrivateKey {
   EcdsaPrivateKey._(); // keep the constructor private.
 
-  // TODO: document or workaround pkcs8 being unsupported on Firefox:
-  //       https://bugzilla.mozilla.org/show_bug.cgi?id=1133698
-  // See: https://github.com/callstats-io/pem-to-jwk/blob/master/index.js#L126
   static Future<EcdsaPrivateKey> importPkcs8Key(
     List<int> keyData,
     EllipticCurve curve,
@@ -48,7 +45,6 @@ abstract class EcdsaPrivateKey {
   Future<Uint8List> signBytes(List<int> data, Hash hash);
   Future<Uint8List> signStream(Stream<List<int>> data, Hash hash);
 
-  // Note. unsupported on Firefox, see EcdsaPrivateKey.importPkcs8Key
   Future<Uint8List> exportPkcs8Key();
 
   Future<Map<String, dynamic>> exportJsonWebKey();


### PR DESCRIPTION
Appears that https://bugzilla.mozilla.org/show_bug.cgi?id=1133698 was fixed -- 3 years ago :see_no_evil: 