### PR TITLE
Attempt to reduce iOS integration test timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,10 @@ jobs:
         with:
           model: 'iPhone 15'
       - run: flutter pub get
+      - run: flutter pub get
+        working-directory: ./example
+      - run: flutter build ios --simulator --target=integration_test/webcrypto_test.dart
+        working-directory: ./example
       - run: flutter test integration_test/webcrypto_test.dart -d iphone
         working-directory: ./example
   android:


### PR DESCRIPTION
Trying out the suggestion from:
https://github.com/flutter/flutter/issues/105913#issuecomment-1500767101

Probably I should gather more data, to know if it's often remotely close to taking 12 minutes (which would be surprising).