### PR TITLE
Fix build error with Xcode 16

### DIFF
--- a/darwin/webcrypto.podspec
+++ b/darwin/webcrypto.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   s.compiler_flags      = [
     '-DOPENSSL_NO_ASM',
     '-DDOPENSSL_SMALL',
-    '-GCC_WARN_INHIBIT_ALL_WARNINGS',
     '-w',
   ]
 


### PR DESCRIPTION
close: #150 

Remove the `GCC_WARN_INHIBIT_ALL_WARNINGS' option, which is not supported in Xcode 16.
This option is intended to reduce the number of warnings and, of course, has no effect on the operation of the library.