### PR TITLE
Disable chromedriver tests on macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,14 +56,15 @@ jobs:
       - run: flutter test --platform chrome
       - run: flutter test integration_test/webcrypto_test.dart -d macos
         working-directory: ./example
-      - uses: nanasess/setup-chromedriver@v2
-      - name: Run integration_test with chromedriver
-        working-directory: ./example
-        run: |
-          ../tool/with-chromedriver.sh flutter drive \
-            --driver=test_driver/integration_test.dart \
-            --target=integration_test/webcrypto_test.dart \
-            -d chrome
+      # TODO: Enable chromdriver testing on MacOS when it works reliably
+      #- uses: nanasess/setup-chromedriver@v2
+      #- name: Run integration_test with chromedriver
+      #  working-directory: ./example
+      #  run: |
+      #    ../tool/with-chromedriver.sh flutter drive \
+      #      --driver=test_driver/integration_test.dart \
+      #      --target=integration_test/webcrypto_test.dart \
+      #      -d chrome
       - run: flutter pub run test -p vm,chrome # TODO: Enable firefox if it works
   windows:
     name: webcrypto on Windows desktop / Chrome / Firefox


### PR DESCRIPTION
This is effectively integration tests for Chrome on MacOS. These tests shouldn't really be necessary, since we tests chrome compatibility in multiple ways.

For unknown reasons these tests are unreliable on MacOS. They were constantly timing out for no good reason.