### PR TITLE
feat: Replace dart:html with dart:js_interop

### DIFF
--- a/lib/src/testing/utils/detected_runtime.dart
+++ b/lib/src/testing/utils/detected_runtime.dart
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 import 'detected_runtime_stub.dart'
-    if (dart.library.html) 'detected_runtime_html.dart';
+    if (dart.library.js_interop) 'detected_runtime_js_interop.dart';
 
 export 'detected_runtime_stub.dart'
-    if (dart.library.html) 'detected_runtime_html.dart' show detectedRuntime;
+    if (dart.library.js_interop) 'detected_runtime_js_interop.dart'
+    show detectedRuntime;
 
 /// Return `null` instead of [value] on Firefox.
 ///

--- a/lib/src/testing/utils/detected_runtime_js_interop.dart
+++ b/lib/src/testing/utils/detected_runtime_js_interop.dart
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' show window;
+import 'dart:js_interop';
+
+@JS('window.navigator.userAgent')
+external String get userAgent;
 
 /// Detected runtime based on [rendering engine][1], this is one of:
 ///  * `'firefox'` (if rendering engine is `'gecko'`),
@@ -32,7 +34,7 @@ import 'dart:html' show window;
 ///
 /// [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent
 final String detectedRuntime = () {
-  final ua = window.navigator.userAgent;
+  final ua = userAgent;
 
   if (ua.contains('Gecko/')) {
     return 'firefox';


### PR DESCRIPTION
ref https://github.com/google/webcrypto.dart/pull/178

Replace `dart:html` with `dart:js_interop` to support wasm builds.