### PR TITLE
Move EC Key Generation off the main-thread with Isolates

### DIFF
--- a/lib/src/impl_ffi/impl_ffi.dart
+++ b/lib/src/impl_ffi/impl_ffi.dart
@@ -20,6 +20,7 @@ import 'dart:async';
 import 'dart:ffi' show Allocator;
 import 'dart:typed_data';
 import 'dart:convert' show utf8, base64Url;
+import 'dart:isolate';
 import 'dart:ffi' as ffi;
 import 'dart:math' as math;
 import 'package:meta/meta.dart';

--- a/lib/src/impl_ffi/impl_ffi.ecdh.dart
+++ b/lib/src/impl_ffi/impl_ffi.ecdh.dart
@@ -38,7 +38,7 @@ Future<KeyPair<EcdhPrivateKeyImpl, EcdhPublicKeyImpl>>
     ecdhPrivateKey_generateKey(
   EllipticCurve curve,
 ) async {
-  final p = _generateEcKeyPair(curve);
+  final p = await _generateEcKeyPair(curve);
   return (
     privateKey: _EcdhPrivateKeyImpl(p.privateKey),
     publicKey: _EcdhPublicKeyImpl(p.publicKey),

--- a/lib/src/impl_ffi/impl_ffi.ecdsa.dart
+++ b/lib/src/impl_ffi/impl_ffi.ecdsa.dart
@@ -54,7 +54,7 @@ Future<KeyPair<EcdsaPrivateKeyImpl, EcdsaPublicKeyImpl>>
     ecdsaPrivateKey_generateKey(
   EllipticCurve curve,
 ) async {
-  final p = _generateEcKeyPair(curve);
+  final p = await _generateEcKeyPair(curve);
   return (
     privateKey: _EcdsaPrivateKeyImpl(p.privateKey),
     publicKey: _EcdsaPublicKeyImpl(p.publicKey),


### PR DESCRIPTION
Part of https://github.com/google/webcrypto.dart/issues/198

EC key generation is faster and less likely to block the main thread because it uses scalar multiplication on elliptic curves, which is significantly less expensive than the prime generation and modular arithmetic involved in RSA. We're making a similar change here to ensure consistency across key generation paths and to ensure responsiveness.