### PR TITLE
Bump minimum required CMake version to 3.10

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.10.0)
 project("webcrypto" LANGUAGES C)
 
 enable_language(ASM)

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.10.0)
 set(PROJECT_NAME "webcrypto")
 project(${PROJECT_NAME} LANGUAGES C CXX)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@
 #
 # This script is very similar to platform specific build scripts.
 
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.10.0)
 project(webcrypto)
 
 enable_language(ASM)


### PR DESCRIPTION
Fixes the following deprecation warning:

    Compatibility with CMake < 3.10 will be removed from a future version of
    CMake.

CMake 3.10 was released in 2017.