### PR TITLE
ci(android): use x86_64 emulator on API 33 for Flutter tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,10 +192,13 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: Run flutter test integration_test/webcrypto_test.dart -d android
+      - name: Run flutter test integration_test/webcrypto_test.dart -d android (x86_64, API 33)
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 28
+          api-level: 33
+          arch: x86_64
+          target: google_apis
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot
           working-directory: ./example
           script: flutter test integration_test/webcrypto_test.dart -d android
   linux-coverage:


### PR DESCRIPTION
Flutter no longer supports 32-bit x86 emulators, so the Android job was failing to find a supported device:

```
Android SDK built for x86 (mobile) • emulator-5554 • unsupported • Android 9 (API 28) (unsupported) (emulator)
```

This updates the emulator configuration to a supported architecture and API level:
- arch: x86_64
- api-level: 33
- target: google_apis
- headless emulator flags

This matches Flutter’s current Android support matrix and resolves the “unsupported (emulator)” device issue.

Fixes #226.
