### PR TITLE
android: restore compileSdk version to default

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 android {
     namespace 'dev.google.webcrypto'
 
-    compileSdkVersion 31
+    compileSdk = flutter.compileSdkVersion
 
     // We depend on cmake for the native parts.
     externalNativeBuild {


### PR DESCRIPTION
Flutter's default version is now higher than 31, so we don't need to manually set this anymore:
https://github.com/flutter/flutter/blob/5c0c9e9e9ad2eec7dc28b216fa55b8c5bf6d7ad9/packages/flutter_tools/gradle/src/main/kotlin/FlutterExtension.kt#L23

Fixes compilation errors with AGP v8.13:

       1.  Dependency 'androidx.fragment:fragment:1.7.1' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :webcrypto is currently compiled against android-31.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).