### PR TITLE
Bump Android API level to 36 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Run flutter test integration_test/webcrypto_test.dart -d android
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 28
+          api-level: 36
           working-directory: ./example
           script: flutter test integration_test/webcrypto_test.dart -d android
   linux-coverage:


### PR DESCRIPTION
This is the version recommended by official Flutter docs: https://docs.flutter.dev/platform-integration/android/setup#set-up-tooling