### PR TITLE
Set max memory page size to 16KB for Android.

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -78,6 +78,9 @@ target_include_directories(
   ../third_party/boringssl/src/include/
 )
 
+# Enforce a 16KB maximum page size for ELF load segments.
+target_link_options(webcrypto PRIVATE "-Wl,--max-page-size=0x4000")
+
 set_target_properties(
   webcrypto
 


### PR DESCRIPTION
Due to new requirements for submitting apps that support 16KB page size to Google Play store I've updated the build script to produce .so files with 16KB page size.
[Official doc](https://developer.android.com/guide/practices/page-sizes#groovy_1) with requirement link.