### PR TITLE
add linker flags for 16kb page size

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -41,6 +41,10 @@ add_definitions(-DOPENSSL_SMALL)
 # set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -flto")
 # set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -flto")
 
+# Add 16KB page size support required by Google Play Store (Android 15+)
+# See: https://developer.android.com/guide/practices/page-sizes
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384")
+
 # Android ABIs, see also:
 # https://developer.android.com/ndk/guides/abis
 if(ANDROID_ABI STREQUAL "armeabi-v7a")


### PR DESCRIPTION
This fixes a new issue where the Play Store will reject apps where page size are not 16kb, which, after having fixed similar things in our app, required webcrypto to be compiled accordingly.


### Example issue reported in the Play Store

<img width="1222" height="270" alt="CleanShot 2025-12-02 at 20 58 32@2x" src="https://github.com/user-attachments/assets/e87aef7d-74e1-4803-94dd-384ac203933e" />
