### PR TITLE
fix: update RFC links to use datatracker.ietf.org

### DIFF
--- a/lib/src/testing/webcrypto/rsapss.dart
+++ b/lib/src/testing/webcrypto/rsapss.dart
@@ -130,7 +130,7 @@ final _testData = [
   /// [3]: https://opensource.apple.com/source/xnu/xnu-4570.41.2/EXTERNAL_HEADERS/corecrypto/ccrsa.h.auto.html
   /// [4]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf
   /// [5]: https://www.rfc-editor.org/rfc/rfc3447
-  /// [6]: https://tools.ietf.org/html/rfc3447#section-9.1
+  /// [6]: https://datatracker.ietf.org/doc/html/rfc3447#section-9.1
   /// [7]: https://bugs.webkit.org/show_bug.cgi?id=216750
   ...(nullOnSafari(_testDataWithLongSaltLength) ?? <Map>[]),
 ];

--- a/lib/src/webcrypto/webcrypto.aescbc.dart
+++ b/lib/src/webcrypto/webcrypto.aescbc.dart
@@ -32,8 +32,8 @@ part of 'webcrypto.dart';
 /// {@macro AesCbcSecretKey-encryptBytes/decryptBytes:example}
 ///
 /// [1]: https://csrc.nist.gov/publications/detail/sp/800-38a/final
-/// [2]: https://tools.ietf.org/html/rfc2315#section-10.3
-/// [3]: https://tools.ietf.org/html/rfc7517
+/// [2]: https://datatracker.ietf.org/doc/html/rfc2315#section-10.3
+/// [3]: https://datatracker.ietf.org/doc/html/rfc7517
 final class AesCbcSecretKey {
   final AesCbcSecretKeyImpl _impl;
 
@@ -106,7 +106,7 @@ final class AesCbcSecretKey {
   /// print(jsonEncode(keyData));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   // TODO: Decide if we want restrictions on "use" property" (we probably have it on web, if we don't strip it)
   // TODO: Decide if we want place restrictions on key_ops
   static Future<AesCbcSecretKey> importJsonWebKey(
@@ -151,7 +151,7 @@ final class AesCbcSecretKey {
   ///
   /// {@template AesCbcSecretKey-encrypt:padding}
   /// Encrypted output is always padded in PKCS#7 mode, as described in
-  /// [RFC 2315 Section 10.3 step 2](https://tools.ietf.org/html/rfc2315#section-10.3).
+  /// [RFC 2315 Section 10.3 step 2](https://datatracker.ietf.org/doc/html/rfc2315#section-10.3).
   /// This padding is stripped when the message is decrypted.
   /// {@endtemplate}
   ///
@@ -238,7 +238,7 @@ final class AesCbcSecretKey {
   /// {@template AesCbcSecretKey-decrypt:padding}
   /// The encrypted [data] is always assumed to be padded in PKCS#7 mode,
   /// as described in
-  /// [RFC 2315 Section 10.3 step 2](https://tools.ietf.org/html/rfc2315#section-10.3).
+  /// [RFC 2315 Section 10.3 step 2](https://datatracker.ietf.org/doc/html/rfc2315#section-10.3).
   /// This padding is stripped from the decrypted return value.
   /// The [encryptBytes] and [encryptStream] methods always apply this padding.
   /// {@endtemplate}
@@ -305,6 +305,6 @@ final class AesCbcSecretKey {
   /// print(jsonEncode(jwk));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   Future<Map<String, dynamic>> exportJsonWebKey() => _impl.exportJsonWebKey();
 }

--- a/lib/src/webcrypto/webcrypto.aesctr.dart
+++ b/lib/src/webcrypto/webcrypto.aesctr.dart
@@ -27,7 +27,7 @@ part of 'webcrypto.dart';
 /// {@macro AesCtrSecretKey-encryptBytes/decryptBytes:example}
 ///
 /// [1]: https://csrc.nist.gov/publications/detail/sp/800-38a/final
-/// [2]: https://tools.ietf.org/html/rfc7517
+/// [2]: https://datatracker.ietf.org/doc/html/rfc7517
 final class AesCtrSecretKey {
   final AesCtrSecretKeyImpl _impl;
 
@@ -103,7 +103,7 @@ final class AesCtrSecretKey {
   /// print(jsonEncode(keyData));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   static Future<AesCtrSecretKey> importJsonWebKey(
     Map<String, dynamic> jwk,
   ) async {
@@ -326,6 +326,6 @@ final class AesCtrSecretKey {
   /// print(jsonEncode(jwk));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   Future<Map<String, dynamic>> exportJsonWebKey() => _impl.exportJsonWebKey();
 }

--- a/lib/src/webcrypto/webcrypto.aesgcm.dart
+++ b/lib/src/webcrypto/webcrypto.aesgcm.dart
@@ -30,7 +30,7 @@ part of 'webcrypto.dart';
 /// {@macro AesGcmSecretKey-encryptBytes/decryptBytes:example}
 ///
 /// [1]: https://csrc.nist.gov/pubs/sp/800/38/d/final
-/// [2]: https://tools.ietf.org/html/rfc7517
+/// [2]: https://datatracker.ietf.org/doc/html/rfc7517
 /// [3]: https://en.wikipedia.org/wiki/Authenticated_encryption
 final class AesGcmSecretKey {
   final AesGcmSecretKeyImpl _impl;
@@ -103,7 +103,7 @@ final class AesGcmSecretKey {
   /// print(jsonEncode(keyData));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   static Future<AesGcmSecretKey> importJsonWebKey(
     Map<String, dynamic> jwk,
   ) async {
@@ -289,6 +289,6 @@ final class AesGcmSecretKey {
   /// print(jsonEncode(jwk));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   Future<Map<String, dynamic>> exportJsonWebKey() => _impl.exportJsonWebKey();
 }

--- a/lib/src/webcrypto/webcrypto.ecdh.dart
+++ b/lib/src/webcrypto/webcrypto.ecdh.dart
@@ -215,9 +215,9 @@ final class EcdhPrivateKey {
   // null for length (in this primitive). However, you can always know the right
   // length from the curve. Note p512 can provide up to: 528 bits!!!
   //
-  // See: https://tools.ietf.org/html/rfc6090#section-4
+  // See: https://datatracker.ietf.org/doc/html/rfc6090#section-4
   // Notice that this is not uniformly distributed, see also:
-  // https://tools.ietf.org/html/rfc6090#appendix-B
+  // https://datatracker.ietf.org/doc/html/rfc6090#appendix-B
   Future<Uint8List> deriveBits(int length, EcdhPublicKey publicKey) async {
     final publicKeyImpl = publicKey._impl;
 

--- a/lib/src/webcrypto/webcrypto.hkdf.dart
+++ b/lib/src/webcrypto/webcrypto.hkdf.dart
@@ -47,7 +47,7 @@ part of 'webcrypto.dart';
 /// ```
 /// {@endtemplate}
 ///
-/// [1]: https://tools.ietf.org/html/rfc5869
+/// [1]: https://datatracker.ietf.org/doc/html/rfc5869
 // TODO: It might be wise to use a random salt, then suggest that the non-secret
 //       salt is stored or exchanged...
 final class HkdfSecretKey {

--- a/lib/src/webcrypto/webcrypto.hmac.dart
+++ b/lib/src/webcrypto/webcrypto.hmac.dart
@@ -143,7 +143,7 @@ final class HmacSecretKey {
   /// print(jsonEncode(keyData));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   static Future<HmacSecretKey> importJsonWebKey(
     // TODO: Determine if the "alg" property can be omitted, and update documentation accordingly
     //       also make tests covering cases where "alg" is omitted.
@@ -383,6 +383,6 @@ final class HmacSecretKey {
   /// print(jsonEncode(jwk));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   Future<Map<String, dynamic>> exportJsonWebKey() => _impl.exportJsonWebKey();
 }

--- a/lib/src/webcrypto/webcrypto.pbkdf2.dart
+++ b/lib/src/webcrypto/webcrypto.pbkdf2.dart
@@ -48,9 +48,7 @@ part of 'webcrypto.dart';
 /// ```
 /// {@endtemplate}
 ///
-/// [1]: https://tools.ietf.org/html/rfc8018
-// TODO: Rewrite all RFC links to use https://www.rfc-editor.org/rfc/rfcXXXX
-
+/// [1]: https://datatracker.ietf.org/doc/html/rfc8018
 final class Pbkdf2SecretKey {
   final Pbkdf2SecretKeyImpl _impl;
 
@@ -87,7 +85,7 @@ final class Pbkdf2SecretKey {
   ///
   /// {@macro Pbkdf2SecretKey:example}
   ///
-  /// [1]: https://tools.ietf.org/html/rfc8018
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc8018
   Future<Uint8List> deriveBits(
     int length,
     Hash hash,

--- a/lib/src/webcrypto/webcrypto.rsaoaep.dart
+++ b/lib/src/webcrypto/webcrypto.rsaoaep.dart
@@ -69,9 +69,9 @@ part of 'webcrypto.dart';
 /// encrypt/decrypt larger messages.
 /// {@endtemplate}
 ///
-/// [1]: https://tools.ietf.org/html/rfc3447
-/// [2]: https://tools.ietf.org/html/rfc5208
-/// [3]: https://tools.ietf.org/html/rfc7517
+/// [1]: https://datatracker.ietf.org/doc/html/rfc3447
+/// [2]: https://datatracker.ietf.org/doc/html/rfc5208
+/// [3]: https://datatracker.ietf.org/doc/html/rfc7517
 final class RsaOaepPrivateKey {
   final RsaOaepPrivateKeyImpl _impl;
 
@@ -113,7 +113,7 @@ final class RsaOaepPrivateKey {
   /// print(PemCodec(PemLabel.privateKey).encode(rawKeyData));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc5208
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc5208
   static Future<RsaOaepPrivateKey> importPkcs8Key(
     List<int> keyData,
     Hash hash,
@@ -164,7 +164,7 @@ final class RsaOaepPrivateKey {
   ///
   /// {@macro RSA-importJsonWebKey:use-key_ops}
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   static Future<RsaOaepPrivateKey> importJsonWebKey(
     Map<String, dynamic> jwk,
     Hash hash,
@@ -307,7 +307,7 @@ final class RsaOaepPrivateKey {
   /// print(PemCodec(PemLabel.privateKey).encode(rawPrivateKey));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc5208
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc5208
   Future<Uint8List> exportPkcs8Key() => _impl.exportPkcs8Key();
 
   /// Export RSAES-OAEP private key in [JSON Web Key][1] format.
@@ -335,7 +335,7 @@ final class RsaOaepPrivateKey {
   /// print(jsonEncode(jwk));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   Future<Map<String, dynamic>> exportJsonWebKey() => _impl.exportJsonWebKey();
 }
 
@@ -355,9 +355,9 @@ final class RsaOaepPrivateKey {
 ///
 /// {@macro RSAES-OAEP-message-size-limit}
 ///
-/// [1]: https://tools.ietf.org/html/rfc3447
-/// [2]: https://tools.ietf.org/html/rfc5280
-/// [3]: https://tools.ietf.org/html/rfc7517
+/// [1]: https://datatracker.ietf.org/doc/html/rfc3447
+/// [2]: https://datatracker.ietf.org/doc/html/rfc5280
+/// [3]: https://datatracker.ietf.org/doc/html/rfc7517
 final class RsaOaepPublicKey {
   final RsaOaepPublicKeyImpl _impl;
 
@@ -399,7 +399,7 @@ final class RsaOaepPublicKey {
   /// print(PemCodec(PemLabel.publicKey).encode(rawKeyData));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc5280
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc5280
   static Future<RsaOaepPublicKey> importSpkiKey(
     List<int> keyData,
     Hash hash,
@@ -444,7 +444,7 @@ final class RsaOaepPublicKey {
   ///
   /// {@macro RSA-importJsonWebKey:use-key_ops}
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   static Future<RsaOaepPublicKey> importJsonWebKey(
     Map<String, dynamic> jwk,
     Hash hash,
@@ -551,7 +551,7 @@ final class RsaOaepPublicKey {
   /// print(PemCodec(PemLabel.publicKey).encode(rawPublicKey));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc5280
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc5280
   Future<Uint8List> exportSpkiKey() => _impl.exportSpkiKey();
 
   /// Export RSAES-OAEP public key in [JSON Web Key][1] format.
@@ -579,6 +579,6 @@ final class RsaOaepPublicKey {
   /// print(jsonEncode(jwk));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   Future<Map<String, dynamic>> exportJsonWebKey() => _impl.exportJsonWebKey();
 }

--- a/lib/src/webcrypto/webcrypto.rsapss.dart
+++ b/lib/src/webcrypto/webcrypto.rsapss.dart
@@ -61,9 +61,9 @@ part of 'webcrypto.dart';
 /// ```
 /// {@endtemplate}
 ///
-/// [1]: https://tools.ietf.org/html/rfc3447
-/// [2]: https://tools.ietf.org/html/rfc5208
-/// [3]: https://tools.ietf.org/html/rfc7517
+/// [1]: https://datatracker.ietf.org/doc/html/rfc3447
+/// [2]: https://datatracker.ietf.org/doc/html/rfc5208
+/// [3]: https://datatracker.ietf.org/doc/html/rfc7517
 final class RsaPssPrivateKey {
   final RsaPssPrivateKeyImpl _impl;
 
@@ -105,7 +105,7 @@ final class RsaPssPrivateKey {
   /// print(PemCodec(PemLabel.privateKey).encode(rawKeyData));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc5208
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc5208
   static Future<RsaPssPrivateKey> importPkcs8Key(
     List<int> keyData,
     Hash hash,
@@ -156,7 +156,7 @@ final class RsaPssPrivateKey {
   ///
   /// {@macro RSA-importJsonWebKey:use-key_ops}
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   static Future<RsaPssPrivateKey> importJsonWebKey(
     Map<String, dynamic> jwk,
     Hash hash,
@@ -280,7 +280,7 @@ final class RsaPssPrivateKey {
   /// print('signature: ${base64.encode(signature)}');
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc3447#section-9.1
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc3447#section-9.1
   /// [2]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf
   ///
   // Notes on saltLength for maintainers:
@@ -354,7 +354,7 @@ final class RsaPssPrivateKey {
   /// print('signature: ${base64.encode(signature)}');
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc3447#section-9.1
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc3447#section-9.1
   /// [2]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf
   Future<Uint8List> signStream(Stream<List<int>> data, int saltLength) =>
       _impl.signStream(data, saltLength);
@@ -385,7 +385,7 @@ final class RsaPssPrivateKey {
   /// print(PemCodec(PemLabel.privateKey).encode(rawPrivateKey));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc5208
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc5208
   Future<Uint8List> exportPkcs8Key() => _impl.exportPkcs8Key();
 
   /// Export RSASSA-PSS private key in [JSON Web Key][1] format.
@@ -413,7 +413,7 @@ final class RsaPssPrivateKey {
   /// print(jsonEncode(jwk));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   Future<Map<String, dynamic>> exportJsonWebKey() => _impl.exportJsonWebKey();
 }
 
@@ -431,9 +431,9 @@ final class RsaPssPrivateKey {
 ///
 /// {@macro RSASSA-PSS-Example:generate-sign-verify}
 ///
-/// [1]: https://tools.ietf.org/html/rfc3447
-/// [2]: https://tools.ietf.org/html/rfc5280
-/// [3]: https://tools.ietf.org/html/rfc7517
+/// [1]: https://datatracker.ietf.org/doc/html/rfc3447
+/// [2]: https://datatracker.ietf.org/doc/html/rfc5280
+/// [3]: https://datatracker.ietf.org/doc/html/rfc7517
 final class RsaPssPublicKey {
   final RsaPssPublicKeyImpl _impl;
 
@@ -475,7 +475,7 @@ final class RsaPssPublicKey {
   /// print(PemCodec(PemLabel.publicKey).encode(rawKeyData));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc5280
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc5280
   static Future<RsaPssPublicKey> importSpkiKey(
     List<int> keyData,
     Hash hash,
@@ -520,7 +520,7 @@ final class RsaPssPublicKey {
   ///
   /// {@macro RSA-importJsonWebKey:use-key_ops}
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   static Future<RsaPssPublicKey> importJsonWebKey(
     Map<String, dynamic> jwk,
     Hash hash,
@@ -651,7 +651,7 @@ final class RsaPssPublicKey {
   /// print(PemCodec(PemLabel.publicKey).encode(rawPublicKey));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc5280
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc5280
   Future<Uint8List> exportSpkiKey() => _impl.exportSpkiKey();
 
   /// Export RSASSA-PSS public key in [JSON Web Key][1] format.
@@ -679,6 +679,6 @@ final class RsaPssPublicKey {
   /// print(jsonEncode(jwk));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   Future<Map<String, dynamic>> exportJsonWebKey() => _impl.exportJsonWebKey();
 }

--- a/lib/src/webcrypto/webcrypto.rsassapkcs1v15.dart
+++ b/lib/src/webcrypto/webcrypto.rsassapkcs1v15.dart
@@ -55,9 +55,9 @@ part of 'webcrypto.dart';
 /// ```
 /// {@endtemplate}
 ///
-/// [1]: https://tools.ietf.org/html/rfc3447
-/// [2]: https://tools.ietf.org/html/rfc5208
-/// [3]: https://tools.ietf.org/html/rfc7517
+/// [1]: https://datatracker.ietf.org/doc/html/rfc3447
+/// [2]: https://datatracker.ietf.org/doc/html/rfc5208
+/// [3]: https://datatracker.ietf.org/doc/html/rfc7517
 final class RsassaPkcs1V15PrivateKey {
   final RsaSsaPkcs1V15PrivateKeyImpl _impl;
 
@@ -101,7 +101,7 @@ final class RsassaPkcs1V15PrivateKey {
   /// print(PemCodec(PemLabel.privateKey).encode(rawKeyData));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc5208
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc5208
   static Future<RsassaPkcs1V15PrivateKey> importPkcs8Key(
     List<int> keyData,
     Hash hash,
@@ -164,7 +164,7 @@ final class RsassaPkcs1V15PrivateKey {
   /// before the JWK is passed to the browser.
   /// {@endtemplate}
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   static Future<RsassaPkcs1V15PrivateKey> importJsonWebKey(
     Map<String, dynamic> jwk,
     Hash hash,
@@ -354,7 +354,7 @@ final class RsassaPkcs1V15PrivateKey {
   /// print(PemCodec(PemLabel.privateKey).encode(rawPrivateKey));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc5208
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc5208
   Future<Uint8List> exportPkcs8Key() => _impl.exportPkcs8Key();
 
   /// Export RSASSA-PKCS1-v1_5 private key in [JSON Web Key][1] format.
@@ -385,7 +385,7 @@ final class RsassaPkcs1V15PrivateKey {
   /// print(jsonEncode(jwk));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   Future<Map<String, dynamic>> exportJsonWebKey() => _impl.exportJsonWebKey();
 }
 
@@ -405,9 +405,9 @@ final class RsassaPkcs1V15PrivateKey {
 ///
 /// {@macro RSASSA-PKCS1-v1_5-Example:generate-sign-verify}
 ///
-/// [1]: https://tools.ietf.org/html/rfc3447
-/// [2]: https://tools.ietf.org/html/rfc5280
-/// [3]: https://tools.ietf.org/html/rfc7517
+/// [1]: https://datatracker.ietf.org/doc/html/rfc3447
+/// [2]: https://datatracker.ietf.org/doc/html/rfc5280
+/// [3]: https://datatracker.ietf.org/doc/html/rfc7517
 final class RsassaPkcs1V15PublicKey {
   final RsaSsaPkcs1V15PublicKeyImpl _impl;
 
@@ -449,7 +449,7 @@ final class RsassaPkcs1V15PublicKey {
   /// print(PemCodec(PemLabel.publicKey).encode(rawKeyData));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc5280
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc5280
   static Future<RsassaPkcs1V15PublicKey> importSpkiKey(
     List<int> keyData,
     Hash hash,
@@ -494,7 +494,7 @@ final class RsassaPkcs1V15PublicKey {
   ///
   /// {@macro RSA-importJsonWebKey:use-key_ops}
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   static Future<RsassaPkcs1V15PublicKey> importJsonWebKey(
     Map<String, dynamic> jwk,
     Hash hash,
@@ -600,7 +600,7 @@ final class RsassaPkcs1V15PublicKey {
   /// print(PemCodec(PemLabel.publicKey).encode(rawPublicKey));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc5280
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc5280
   Future<Uint8List> exportSpkiKey() => _impl.exportSpkiKey();
 
   /// Export RSASSA-PKCS1-v1_5 public key in [JSON Web Key][1] format.
@@ -628,6 +628,6 @@ final class RsassaPkcs1V15PublicKey {
   /// print(jsonEncode(jwk));
   /// ```
   ///
-  /// [1]: https://tools.ietf.org/html/rfc7517
+  /// [1]: https://datatracker.ietf.org/doc/html/rfc7517
   Future<Map<String, dynamic>> exportJsonWebKey() => _impl.exportJsonWebKey();
 }


### PR DESCRIPTION
This is my first contribution to this project. 🙃

I noticed a TODO comment in `webcrypto.pbkdf2.dart` requesting to rewrite RFC links, so I decided to tackle it.

Updated all RFC documentation links from the legacy `tools.ietf.org` domain to the official `datatracker.ietf.org` domain. The old URLs now redirect to the new domain, so this change ensures the documentation references the canonical source directly.

## Changes

- Updated RFC links in 11 files across the codebase
- No functional changes, documentation only

## Test plan

- [x] Verified all new links are accessible and point to the correct RFC sections
- [x] No code logic was modified, only documentation URLs
