### PR TITLE
test: cover ECDH deriveBits length boundaries

### DIFF
--- a/lib/src/testing/ecdh/derive_bits.dart
+++ b/lib/src/testing/ecdh/derive_bits.dart
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:webcrypto/webcrypto.dart';
+import '../utils/detected_runtime.dart';
+import '../utils/utils.dart';
+
+final _cases = [
+  (name: 'P-256', curve: EllipticCurve.p256, maxBits: 256),
+  (name: 'P-384', curve: EllipticCurve.p384, maxBits: 384),
+  (name: 'P-521', curve: EllipticCurve.p521, maxBits: 528),
+];
+
+void main() => tests().runTests();
+
+List<({String name, Future<void> Function() test})> tests() {
+  final tests = <({String name, Future<void> Function() test})>[];
+  void test(String name, Future<void> Function() fn) =>
+      tests.add((name: name, test: fn));
+
+  for (final c in _cases) {
+    if (detectedRuntime == 'safari' && c.curve == EllipticCurve.p521) {
+      continue;
+    }
+
+    test('ECDH: ${c.name} allows maximum deriveBits length', () async {
+      final aliceKeyPair = await EcdhPrivateKey.generateKey(c.curve);
+      final bobKeyPair = await EcdhPrivateKey.generateKey(c.curve);
+
+      final secret = await aliceKeyPair.privateKey.deriveBits(
+        c.maxBits,
+        bobKeyPair.publicKey,
+      );
+
+      check(secret.length == c.maxBits ~/ 8, 'secret length mismatch');
+    });
+
+    test('ECDH: ${c.name} rejects deriveBits larger than maximum', () async {
+      final aliceKeyPair = await EcdhPrivateKey.generateKey(c.curve);
+      final bobKeyPair = await EcdhPrivateKey.generateKey(c.curve);
+
+      var threw = false;
+      try {
+        await aliceKeyPair.privateKey.deriveBits(
+          c.maxBits + 8,
+          bobKeyPair.publicKey,
+        );
+      } on OperationError {
+        threw = true;
+      }
+      check(
+        threw,
+        'Should throw OperationError for deriveBits larger than maximum',
+      );
+    });
+  }
+
+  return tests;
+}

--- a/lib/src/testing/ecdh/derive_bits.dart
+++ b/lib/src/testing/ecdh/derive_bits.dart
@@ -53,7 +53,7 @@ List<({String name, Future<void> Function() test})> tests() {
       var threw = false;
       try {
         await aliceKeyPair.privateKey.deriveBits(
-          c.maxBits + 8,
+          c.maxBits + 1,
           bobKeyPair.publicKey,
         );
       } on OperationError {

--- a/lib/src/testing/ecdh/derive_bits.dart
+++ b/lib/src/testing/ecdh/derive_bits.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'package:webcrypto/webcrypto.dart';
-import '../utils/detected_runtime.dart';
 import '../utils/utils.dart';
 
 final _cases = [
@@ -30,10 +29,6 @@ List<({String name, Future<void> Function() test})> tests() {
       tests.add((name: name, test: fn));
 
   for (final c in _cases) {
-    if (detectedRuntime == 'safari' && c.curve == EllipticCurve.p521) {
-      continue;
-    }
-
     test('ECDH: ${c.name} allows maximum deriveBits length', () async {
       final aliceKeyPair = await EcdhPrivateKey.generateKey(c.curve);
       final bobKeyPair = await EcdhPrivateKey.generateKey(c.curve);

--- a/lib/src/testing/testing.dart
+++ b/lib/src/testing/testing.dart
@@ -30,6 +30,7 @@ import 'webcrypto/rsassapkcs1v15.dart' as rsassapkcs1v15;
 // Other test files, that don't use TestRunner
 import 'webcrypto/random.dart' as random;
 import 'webcrypto/digest.dart' as digest;
+import 'ecdh/derive_bits.dart' as ecdh_derive_bits;
 import 'regression/issue_60_trailing_bytes.dart' as issue_60_trailing_bytes;
 
 /// Test runners from all test files except `digest.dart` and
@@ -59,6 +60,7 @@ void runAllTests(
     for (final r in _testRunners) ...r.tests(),
     ...random.tests(),
     ...digest.tests(),
+    ...ecdh_derive_bits.tests(),
     ...issue_60_trailing_bytes.tests(),
   ];
 

--- a/lib/src/testing/testing.dart
+++ b/lib/src/testing/testing.dart
@@ -34,6 +34,7 @@ import 'regression/aes_gcm_invalid_tag_length.dart'
     as aes_gcm_invalid_tag_length;
 import 'regression/derive_bits_zero_length.dart' as derive_bits_zero_length;
 import 'regression/ecdh_invalid_length.dart' as ecdh_invalid_length;
+import 'ecdh/derive_bits.dart' as ecdh_derive_bits;
 import 'regression/issue_60_trailing_bytes.dart' as issue_60_trailing_bytes;
 import 'regression/jwk_base64url.dart' as jwk_base64url;
 import 'regression/rsa_oaep_sha1_jwk_alg.dart' as rsa_oaep_sha1_jwk_alg;
@@ -67,6 +68,7 @@ void runAllTests(
     ...random.tests(),
     ...digest.tests(),
     ...aes_gcm_invalid_tag_length.tests(),
+    ...ecdh_derive_bits.tests(),
     ...issue_60_trailing_bytes.tests(),
     ...jwk_base64url.tests(),
     ...derive_bits_zero_length.tests(),

--- a/lib/src/testing/webcrypto/ecdh.dart
+++ b/lib/src/testing/webcrypto/ecdh.dart
@@ -65,7 +65,8 @@ void main() async {
     generateKeyParams: {'curve': curveToJson(EllipticCurve.p256)},
     importKeyParams: {'curve': curveToJson(EllipticCurve.p256)},
     deriveParams: {},
-    maxDeriveLength: 32,
+    minDeriveLength: 256,
+    maxDeriveLength: 256,
   );
 
   // P-384: up to 384 bits (48 bytes)
@@ -73,7 +74,8 @@ void main() async {
     generateKeyParams: {'curve': curveToJson(EllipticCurve.p384)},
     importKeyParams: {'curve': curveToJson(EllipticCurve.p384)},
     deriveParams: {},
-    maxDeriveLength: 48,
+    minDeriveLength: 384,
+    maxDeriveLength: 384,
   );
 
   // P-521: up to 528 bits (66 bytes)
@@ -81,7 +83,8 @@ void main() async {
     generateKeyParams: {'curve': curveToJson(EllipticCurve.p521)},
     importKeyParams: {'curve': curveToJson(EllipticCurve.p521)},
     deriveParams: {},
-    maxDeriveLength: 66,
+    minDeriveLength: 528,
+    maxDeriveLength: 528,
   );
 
   log('--------------------');

--- a/lib/src/webcrypto/webcrypto.ecdh.dart
+++ b/lib/src/webcrypto/webcrypto.ecdh.dart
@@ -206,6 +206,10 @@ final class EcdhPrivateKey {
   /// two parties.
   ///
   /// [length] specifies the length of the derived secret in bits.
+  /// The maximum allowed [length] is determined by the elliptic curve:
+  ///  * [EllipticCurve.p256] can derive up to 256 bits.
+  ///  * [EllipticCurve.p384] can derive up to 384 bits.
+  ///  * [EllipticCurve.p521] can derive up to 528 bits.
   /// [publicKey] is [EcdhPublicKey] from the other party's ECDH key pair.
   ///
   /// Returns a [Uint8List] containing the derived shared secret.


### PR DESCRIPTION
Follow-up to #289.

This change adds explicit ECDH `deriveBits` boundary coverage for each supported curve:

- exercises the exact maximum length in generated cases;
- verifies the documented maximum succeeds; and
- verifies the first invalid bit length is rejected.

The tested limits are 256 bits for P-256, 384 bits for P-384, and 528 bits for P-521.