### PR TITLE
docs: make dartdoc examples self-contained

### DIFF
--- a/lib/src/webcrypto/webcrypto.aescbc.dart
+++ b/lib/src/webcrypto/webcrypto.aescbc.dart
@@ -56,19 +56,21 @@ final class AesCbcSecretKey {
   /// import 'dart:typed_data' show Uint8List;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// final rawKey = Uint8List(16);
-  /// fillRandomBytes(rawKey);
+  /// Future<void> main() async {
+  ///   final rawKey = Uint8List(16);
+  ///   fillRandomBytes(rawKey);
   ///
-  /// final k = await AesCbcSecretKey.importRawKey(rawKey);
+  ///   final k = await AesCbcSecretKey.importRawKey(rawKey);
   ///
-  /// // Use a unique IV for each message.
-  /// final iv = Uint8List(16);
-  /// fillRandomBytes(iv);
+  ///   // Use a unique IV for each message.
+  ///   final iv = Uint8List(16);
+  ///   fillRandomBytes(iv);
   ///
-  /// // Encrypt a message
-  /// final c = await k.encryptBytes(utf8.encode('hello world'), iv);
+  ///   // Encrypt a message
+  ///   final c = await k.encryptBytes(utf8.encode('hello world'), iv);
   ///
-  /// print(utf8.decode(await k.decryptBytes(c, iv))); // hello world
+  ///   print(utf8.decode(await k.decryptBytes(c, iv))); // hello world
+  /// }
   /// ```
   static Future<AesCbcSecretKey> importRawKey(List<int> keyData) async {
     final impl = await webCryptImpl.aesCbcSecretKey.importRawKey(keyData);
@@ -95,15 +97,17 @@ final class AesCbcSecretKey {
   /// import 'dart:convert' show jsonEncode, jsonDecode;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // JSON Web Key as a string containing JSON.
-  /// final jwk = '{"kty": "oct", "alg": "A256CBC", "k": ...}';
+  /// Future<void> main() async {
+  ///   // JSON Web Key as a string containing JSON.
+  ///   final jwk = '{"kty": "oct", "alg": "A256CBC", "k": ...}';
   ///
-  /// // Import secret key from decoded JSON.
-  /// final key = await AesCbcSecretKey.importJsonWebKey(jsonDecode(jwk));
+  ///   // Import secret key from decoded JSON.
+  ///   final key = await AesCbcSecretKey.importJsonWebKey(jsonDecode(jwk));
   ///
-  /// // Export the key (print it in same format as it was given).
-  /// Map<String, dynamic> keyData = await key.exportJsonWebKey();
-  /// print(jsonEncode(keyData));
+  ///   // Export the key (print it in same format as it was given).
+  ///   Map<String, dynamic> keyData = await key.exportJsonWebKey();
+  ///   print(jsonEncode(keyData));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517
@@ -129,8 +133,10 @@ final class AesCbcSecretKey {
   /// ```dart
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a new random AES-CBC secret key for AES-256.
-  /// final key = await AesCbcSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-CBC secret key for AES-256.
+  ///   final key = await AesCbcSecretKey.generate(256);
+  /// }
   /// ```
   static Future<AesCbcSecretKey> generateKey(int length) async {
     final impl = await webCryptImpl.aesCbcSecretKey.generateKey(length);
@@ -162,18 +168,20 @@ final class AesCbcSecretKey {
   /// import 'dart:typed_data' show Uint8List;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a new random AES-CBC secret key for AES-256.
-  /// final k = await AesCbcSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-CBC secret key for AES-256.
+  ///   final k = await AesCbcSecretKey.generate(256);
   ///
-  /// // Use a unique IV for each message.
-  /// final iv = Uint8List(16);
-  /// fillRandomBytes(iv);
+  ///   // Use a unique IV for each message.
+  ///   final iv = Uint8List(16);
+  ///   fillRandomBytes(iv);
   ///
-  /// // Encrypt a message
-  /// final c = await k.encryptBytes(utf8.encode('hello world'), iv);
+  ///   // Encrypt a message
+  ///   final c = await k.encryptBytes(utf8.encode('hello world'), iv);
   ///
-  /// // Decrypt message (requires the same iv)
-  /// print(utf8.decode(await k.decryptBytes(c, iv))); // hello world
+  ///   // Decrypt message (requires the same iv)
+  ///   print(utf8.decode(await k.decryptBytes(c, iv))); // hello world
+  /// }
   /// ```
   /// {@endtemplate}
   ///
@@ -197,28 +205,30 @@ final class AesCbcSecretKey {
   /// import 'package:async/async.dart' show collectBytes;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a new random AES-CBC secret key for AES-256.
-  /// final k = await AesCbcSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-CBC secret key for AES-256.
+  ///   final k = await AesCbcSecretKey.generate(256);
   ///
-  /// // Use a unique IV for each message.
-  /// final iv = Uint8List(16);
-  /// fillRandomBytes(iv);
+  ///   // Use a unique IV for each message.
+  ///   final iv = Uint8List(16);
+  ///   fillRandomBytes(iv);
   ///
-  /// // Encrypt a message from file and write to file
-  /// final inputFile = File('message.txt');
-  /// final encryptedFile = File('encrypted-message.binary');
-  /// final c = await k.encryptStream(
-  ///   inputFile.openRead(),
-  ///   iv,
-  /// ).pipe(encryptedFile.openWrite());
+  ///   // Encrypt a message from file and write to file
+  ///   final inputFile = File('message.txt');
+  ///   final encryptedFile = File('encrypted-message.binary');
+  ///   final c = await k.encryptStream(
+  ///     inputFile.openRead(),
+  ///     iv,
+  ///   ).pipe(encryptedFile.openWrite());
   ///
-  /// // Decrypt message (requires the same iv)
-  /// final decryptedBytes = await collectBytes(k.decryptStream(
-  ///   encryptedFile.openRead(),
-  ///   iv, // same iv as used for encryption
-  /// ));
-  /// // decryptedBytes should be equal to contents of inputFile
-  /// assert(utf8.decode(decryptedBytes) == inputFile.readAsStringSync());
+  ///   // Decrypt message (requires the same iv)
+  ///   final decryptedBytes = await collectBytes(k.decryptStream(
+  ///     encryptedFile.openRead(),
+  ///     iv, // same iv as used for encryption
+  ///   ));
+  ///   // decryptedBytes should be equal to contents of inputFile
+  ///   assert(utf8.decode(decryptedBytes) == inputFile.readAsStringSync());
+  /// }
   /// ```
   /// {@endtemplate}
   ///
@@ -270,17 +280,19 @@ final class AesCbcSecretKey {
   /// ```dart
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a new random AES-256 secret key.
-  /// final key = await AesCbcSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-256 secret key.
+  ///   final key = await AesCbcSecretKey.generate(256);
   ///
-  /// // Extract the secret key.
-  /// final secretBytes = await key.exportRawKey();
+  ///   // Extract the secret key.
+  ///   final secretBytes = await key.exportRawKey();
   ///
-  /// // Print the key as base64
-  /// print(base64.encode(secretBytes));
+  ///   // Print the key as base64
+  ///   print(base64.encode(secretBytes));
   ///
-  /// // If we wanted to we could import the key as follows:
-  /// // key = await AesCbcSecretKey.importRawKey(secretBytes);
+  ///   // If we wanted to we could import the key as follows:
+  ///   // key = await AesCbcSecretKey.importRawKey(secretBytes);
+  /// }
   /// ```
   Future<Uint8List> exportRawKey() => _impl.exportRawKey();
 
@@ -293,16 +305,18 @@ final class AesCbcSecretKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode;
   ///
-  /// // Generate a new random AES-256 secret key.
-  /// final key = await AesCbcSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-256 secret key.
+  ///   final key = await AesCbcSecretKey.generate(256);
   ///
-  /// // Export the secret key.
-  /// final jwk = await key.exportJsonWebKey();
+  ///   // Export the secret key.
+  ///   final jwk = await key.exportJsonWebKey();
   ///
-  /// // The Map returned by `exportJsonWebKey()` can be converted to JSON with
-  /// // `jsonEncode` from `dart:convert`, this will print something like:
-  /// // {"kty": "oct", "alg": "A256CBC", "k": ...}
-  /// print(jsonEncode(jwk));
+  ///   // The Map returned by `exportJsonWebKey()` can be converted to JSON with
+  ///   // `jsonEncode` from `dart:convert`, this will print something like:
+  ///   // {"kty": "oct", "alg": "A256CBC", "k": ...}
+  ///   print(jsonEncode(jwk));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517

--- a/lib/src/webcrypto/webcrypto.aesctr.dart
+++ b/lib/src/webcrypto/webcrypto.aesctr.dart
@@ -47,25 +47,27 @@ final class AesCtrSecretKey {
   /// import 'dart:typed_data' show Uint8List;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// final rawKey = Uint8List(16);
-  /// fillRandomBytes(rawKey);
+  /// Future<void> main() async {
+  ///   final rawKey = Uint8List(16);
+  ///   fillRandomBytes(rawKey);
   ///
-  /// // Import key from raw bytes
-  /// final k = await AesCtrSecretKey.importRawKey(rawKey);
+  ///   // Import key from raw bytes
+  ///   final k = await AesCtrSecretKey.importRawKey(rawKey);
   ///
-  /// // Use a unique counter for each message.
-  /// final ctr = Uint8List(16); // always 16 bytes
-  /// fillRandomBytes(ctr);
+  ///   // Use a unique counter for each message.
+  ///   final ctr = Uint8List(16); // always 16 bytes
+  ///   fillRandomBytes(ctr);
   ///
-  /// // Length of the counter, the N'th right most bits of ctr are incremented
-  /// // for each block, the left most 128 - N bits are used as static nonce.
-  /// final N = 64;
+  ///   // Length of the counter, the N'th right most bits of ctr are incremented
+  ///   // for each block, the left most 128 - N bits are used as static nonce.
+  ///   final N = 64;
   ///
-  /// // Encrypt a message
-  /// final c = await k.encryptBytes(utf8.encode('hello world'), ctr, N);
+  ///   // Encrypt a message
+  ///   final c = await k.encryptBytes(utf8.encode('hello world'), ctr, N);
   ///
-  /// // Decrypt message (requires the same counter ctr and length N)
-  /// print(utf8.decode(await k.decryptBytes(c, ctr, N))); // hello world
+  ///   // Decrypt message (requires the same counter ctr and length N)
+  ///   print(utf8.decode(await k.decryptBytes(c, ctr, N))); // hello world
+  /// }
   /// ```
   static Future<AesCtrSecretKey> importRawKey(List<int> keyData) async {
     final impl = await webCryptImpl.aesCtrSecretKey.importRawKey(keyData);
@@ -92,15 +94,17 @@ final class AesCtrSecretKey {
   /// import 'dart:convert' show jsonEncode, jsonDecode;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // JSON Web Key as a string containing JSON.
-  /// final jwk = '{"kty": "oct", "alg": "A256CTR", "k": ...}';
+  /// Future<void> main() async {
+  ///   // JSON Web Key as a string containing JSON.
+  ///   final jwk = '{"kty": "oct", "alg": "A256CTR", "k": ...}';
   ///
-  /// // Import secret key from decoded JSON.
-  /// final key = await AesCtrSecretKey.importJsonWebKey(jsonDecode(jwk));
+  ///   // Import secret key from decoded JSON.
+  ///   final key = await AesCtrSecretKey.importJsonWebKey(jsonDecode(jwk));
   ///
-  /// // Export the key (print it in same format as it was given).
-  /// Map<String, dynamic> keyData = await key.exportJsonWebKey();
-  /// print(jsonEncode(keyData));
+  ///   // Export the key (print it in same format as it was given).
+  ///   Map<String, dynamic> keyData = await key.exportJsonWebKey();
+  ///   print(jsonEncode(keyData));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517
@@ -124,8 +128,10 @@ final class AesCtrSecretKey {
   /// ```dart
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a new random AES-CTR secret key for AES-256.
-  /// final key = await AesCtrSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-CTR secret key for AES-256.
+  ///   final key = await AesCtrSecretKey.generate(256);
+  /// }
   /// ```
   static Future<AesCtrSecretKey> generateKey(int length) async {
     final impl = await webCryptImpl.aesCtrSecretKey.generateKey(length);
@@ -153,23 +159,25 @@ final class AesCtrSecretKey {
   /// import 'dart:typed_data' show Uint8List;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a new random AES-CTR secret key for AES-256.
-  /// final k = await AesCtrSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-CTR secret key for AES-256.
+  ///   final k = await AesCtrSecretKey.generate(256);
   ///
-  /// // Use a unique counter for each message.
-  /// final ctr = Uint8List(16); // always 16 bytes
-  /// fillRandomBytes(ctr);
+  ///   // Use a unique counter for each message.
+  ///   final ctr = Uint8List(16); // always 16 bytes
+  ///   fillRandomBytes(ctr);
   ///
-  /// // Length of the counter, the N'th right most bits of ctr are incremented
-  /// // for each block, the left most 128 - N bits are used as static nonce.
-  /// // Thus, messages must be less than 2^64 * 16 bytes.
-  /// final N = 64;
+  ///   // Length of the counter, the N'th right most bits of ctr are incremented
+  ///   // for each block, the left most 128 - N bits are used as static nonce.
+  ///   // Thus, messages must be less than 2^64 * 16 bytes.
+  ///   final N = 64;
   ///
-  /// // Encrypt a message
-  /// final c = await k.encryptBytes(utf8.encode('hello world'), ctr, N);
+  ///   // Encrypt a message
+  ///   final c = await k.encryptBytes(utf8.encode('hello world'), ctr, N);
   ///
-  /// // Decrypt message (requires the same counter ctr and length N)
-  /// print(utf8.decode(await k.decryptBytes(c, ctr, N))); // hello world
+  ///   // Decrypt message (requires the same counter ctr and length N)
+  ///   print(utf8.decode(await k.decryptBytes(c, ctr, N))); // hello world
+  /// }
   /// ```
   /// {@endtemplate}
   ///
@@ -203,36 +211,38 @@ final class AesCtrSecretKey {
   /// import 'package:async/async.dart' show collectBytes;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a new random AES-CTR secret key for AES-256.
-  /// final k = await AesCtrSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-CTR secret key for AES-256.
+  ///   final k = await AesCtrSecretKey.generate(256);
   ///
-  /// // Use a unique counter for each message.
-  /// final ctr = Uint8List(16); // always 16 bytes
-  /// fillRandomBytes(ctr);
+  ///   // Use a unique counter for each message.
+  ///   final ctr = Uint8List(16); // always 16 bytes
+  ///   fillRandomBytes(ctr);
   ///
-  /// // Length of the counter, the N'th right most bits of ctr are incremented
-  /// // for each block, the left most 128 - N bits are used as static nonce.
-  /// // Thus, messages must be less than 2^64 * 16 bytes.
-  /// final N = 64;
+  ///   // Length of the counter, the N'th right most bits of ctr are incremented
+  ///   // for each block, the left most 128 - N bits are used as static nonce.
+  ///   // Thus, messages must be less than 2^64 * 16 bytes.
+  ///   final N = 64;
   ///
-  /// // Encrypt a message from file and write to file
-  /// final inputFile = File('message.txt');
-  /// final encryptedFile = File('encrypted-message.binary');
-  /// final c = await k.encryptStream(
-  ///   inputFile.openRead(),
-  ///   ctr,
-  ///   N,
-  /// ).pipe(encryptedFile.openWrite());
+  ///   // Encrypt a message from file and write to file
+  ///   final inputFile = File('message.txt');
+  ///   final encryptedFile = File('encrypted-message.binary');
+  ///   final c = await k.encryptStream(
+  ///     inputFile.openRead(),
+  ///     ctr,
+  ///     N,
+  ///   ).pipe(encryptedFile.openWrite());
   ///
   ///
-  /// // Decrypt message (requires the same counter ctr and length N)
-  /// final decryptedBytes = await collectBytes(k.decryptStream(
-  ///   encryptedFile.openRead(),
-  ///   ctr, // same ctr as used for encryption
-  ///   N, // same N as used for encryption
-  /// ));
-  /// // decryptedBytes should be equal to contents of inputFile
-  /// assert(utf8.decode(decryptedBytes) == inputFile.readAsStringSync());
+  ///   // Decrypt message (requires the same counter ctr and length N)
+  ///   final decryptedBytes = await collectBytes(k.decryptStream(
+  ///     encryptedFile.openRead(),
+  ///     ctr, // same ctr as used for encryption
+  ///     N, // same N as used for encryption
+  ///   ));
+  ///   // decryptedBytes should be equal to contents of inputFile
+  ///   assert(utf8.decode(decryptedBytes) == inputFile.readAsStringSync());
+  /// }
   /// ```
   /// {@endtemplate}
   ///
@@ -291,17 +301,19 @@ final class AesCtrSecretKey {
   /// ```dart
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a new random AES-256 secret key.
-  /// final key = await AesCtrSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-256 secret key.
+  ///   final key = await AesCtrSecretKey.generate(256);
   ///
-  /// // Extract the secret key.
-  /// final secretBytes = await key.exportRawKey();
+  ///   // Extract the secret key.
+  ///   final secretBytes = await key.exportRawKey();
   ///
-  /// // Print the key as base64
-  /// print(base64.encode(secretBytes));
+  ///   // Print the key as base64
+  ///   print(base64.encode(secretBytes));
   ///
-  /// // If we wanted to we could import the key as follows:
-  /// // key = await AesCtrSecretKey.importRawKey(secretBytes);
+  ///   // If we wanted to we could import the key as follows:
+  ///   // key = await AesCtrSecretKey.importRawKey(secretBytes);
+  /// }
   /// ```
   Future<Uint8List> exportRawKey() => _impl.exportRawKey();
 
@@ -314,16 +326,18 @@ final class AesCtrSecretKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode;
   ///
-  /// // Generate a new random AES-256 secret key.
-  /// final key = await AesCtrSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-256 secret key.
+  ///   final key = await AesCtrSecretKey.generate(256);
   ///
-  /// // Export the secret key.
-  /// final jwk = await key.exportJsonWebKey();
+  ///   // Export the secret key.
+  ///   final jwk = await key.exportJsonWebKey();
   ///
-  /// // The Map returned by `exportJsonWebKey()` can be converted to JSON with
-  /// // `jsonEncode` from `dart:convert`, this will print something like:
-  /// // {"kty": "oct", "alg": "A256CTR", "k": ...}
-  /// print(jsonEncode(jwk));
+  ///   // The Map returned by `exportJsonWebKey()` can be converted to JSON with
+  ///   // `jsonEncode` from `dart:convert`, this will print something like:
+  ///   // {"kty": "oct", "alg": "A256CTR", "k": ...}
+  ///   print(jsonEncode(jwk));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517

--- a/lib/src/webcrypto/webcrypto.aesgcm.dart
+++ b/lib/src/webcrypto/webcrypto.aesgcm.dart
@@ -51,21 +51,23 @@ final class AesGcmSecretKey {
   /// import 'dart:typed_data' show Uint8List;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// final rawKey = Uint8List(16);
-  /// fillRandomBytes(rawKey);
+  /// Future<void> main() async {
+  ///   final rawKey = Uint8List(16);
+  ///   fillRandomBytes(rawKey);
   ///
-  /// // Import key from raw bytes
-  /// final k = await AesGcmSecretKey.importRawKey(rawKey);
+  ///   // Import key from raw bytes
+  ///   final k = await AesGcmSecretKey.importRawKey(rawKey);
   ///
-  /// // Use a unique IV for each message.
-  /// final iv = Uint8List(16);
-  /// fillRandomBytes(iv);
+  ///   // Use a unique IV for each message.
+  ///   final iv = Uint8List(16);
+  ///   fillRandomBytes(iv);
   ///
-  /// // Encrypt a message
-  /// final c = await k.encryptBytes(utf8.encode('hello world'), iv);
+  ///   // Encrypt a message
+  ///   final c = await k.encryptBytes(utf8.encode('hello world'), iv);
   ///
-  /// // Decrypt message (requires the same iv)
-  /// print(utf8.decode(await k.decryptBytes(c, iv))); // hello world
+  ///   // Decrypt message (requires the same iv)
+  ///   print(utf8.decode(await k.decryptBytes(c, iv))); // hello world
+  /// }
   /// ```
   static Future<AesGcmSecretKey> importRawKey(List<int> keyData) async {
     final impl = await webCryptImpl.aesGcmSecretKey.importRawKey(keyData);
@@ -92,15 +94,17 @@ final class AesGcmSecretKey {
   /// import 'dart:convert' show jsonEncode, jsonDecode;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // JSON Web Key as a string containing JSON.
-  /// final jwk = '{"kty": "oct", "alg": "A256GCM", "k": ...}';
+  /// Future<void> main() async {
+  ///   // JSON Web Key as a string containing JSON.
+  ///   final jwk = '{"kty": "oct", "alg": "A256GCM", "k": ...}';
   ///
-  /// // Import secret key from decoded JSON.
-  /// final key = await AesGcmSecretKey.importJsonWebKey(jsonDecode(jwk));
+  ///   // Import secret key from decoded JSON.
+  ///   final key = await AesGcmSecretKey.importJsonWebKey(jsonDecode(jwk));
   ///
-  /// // Export the key (print it in same format as it was given).
-  /// Map<String, dynamic> keyData = await key.exportJsonWebKey();
-  /// print(jsonEncode(keyData));
+  ///   // Export the key (print it in same format as it was given).
+  ///   Map<String, dynamic> keyData = await key.exportJsonWebKey();
+  ///   print(jsonEncode(keyData));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517
@@ -124,8 +128,10 @@ final class AesGcmSecretKey {
   /// ```dart
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a new random AES-GCM secret key for AES-256.
-  /// final key = await AesGcmSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-GCM secret key for AES-256.
+  ///   final key = await AesGcmSecretKey.generate(256);
+  /// }
   /// ```
   static Future<AesGcmSecretKey> generateKey(int length) async {
     final impl = await webCryptImpl.aesGcmSecretKey.generateKey(length);
@@ -181,29 +187,31 @@ final class AesGcmSecretKey {
   /// import 'dart:typed_data' show Uint8List;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a new random AES-GCM secret key for AES-256.
-  /// final k = await AesGcmSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-GCM secret key for AES-256.
+  ///   final k = await AesGcmSecretKey.generate(256);
   ///
-  /// // Use a unique IV for each message.
-  /// final iv = Uint8List(16);
-  /// fillRandomBytes(iv);
+  ///   // Use a unique IV for each message.
+  ///   final iv = Uint8List(16);
+  ///   fillRandomBytes(iv);
   ///
-  /// // Specify optional additionalData
-  /// final ad = utf8.encode('my-test-message');
+  ///   // Specify optional additionalData
+  ///   final ad = utf8.encode('my-test-message');
   ///
-  /// // Encrypt a message
-  /// final c = await k.encryptBytes(
-  ///   utf8.encode('hello world'),
-  ///   iv,
-  ///   additionalData: ad,
-  /// );
+  ///   // Encrypt a message
+  ///   final c = await k.encryptBytes(
+  ///     utf8.encode('hello world'),
+  ///     iv,
+  ///     additionalData: ad,
+  ///   );
   ///
-  /// // Decrypt message (requires the same iv)
-  /// print(utf8.decode(await k.decryptBytes(
-  ///   c,
-  ///   iv,
-  ///   additionalData: ad,
-  /// ))); // hello world
+  ///   // Decrypt message (requires the same iv)
+  ///   print(utf8.decode(await k.decryptBytes(
+  ///     c,
+  ///     iv,
+  ///     additionalData: ad,
+  ///   ))); // hello world
+  /// }
   /// ```
   /// {@endtemplate}
   ///
@@ -254,17 +262,19 @@ final class AesGcmSecretKey {
   /// ```dart
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a new random AES-256 secret key.
-  /// final key = await AesGcmSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-256 secret key.
+  ///   final key = await AesGcmSecretKey.generate(256);
   ///
-  /// // Extract the secret key.
-  /// final secretBytes = await key.exportRawKey();
+  ///   // Extract the secret key.
+  ///   final secretBytes = await key.exportRawKey();
   ///
-  /// // Print the key as base64
-  /// print(base64.encode(secretBytes));
+  ///   // Print the key as base64
+  ///   print(base64.encode(secretBytes));
   ///
-  /// // If we wanted to we could import the key as follows:
-  /// // key = await AesGcmSecretKey.importRawKey(secretBytes);
+  ///   // If we wanted to we could import the key as follows:
+  ///   // key = await AesGcmSecretKey.importRawKey(secretBytes);
+  /// }
   /// ```
   Future<Uint8List> exportRawKey() => _impl.exportRawKey();
 
@@ -277,16 +287,18 @@ final class AesGcmSecretKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode;
   ///
-  /// // Generate a new random AES-256 secret key.
-  /// final key = await AesGcmSecretKey.generate(256);
+  /// Future<void> main() async {
+  ///   // Generate a new random AES-256 secret key.
+  ///   final key = await AesGcmSecretKey.generate(256);
   ///
-  /// // Export the secret key.
-  /// final jwk = await key.exportJsonWebKey();
+  ///   // Export the secret key.
+  ///   final jwk = await key.exportJsonWebKey();
   ///
-  /// // The Map returned by `exportJsonWebKey()` can be converted to JSON with
-  /// // `jsonEncode` from `dart:convert`, this will print something like:
-  /// // {"kty": "oct", "alg": "A256GCM", "k": ...}
-  /// print(jsonEncode(jwk));
+  ///   // The Map returned by `exportJsonWebKey()` can be converted to JSON with
+  ///   // `jsonEncode` from `dart:convert`, this will print something like:
+  ///   // {"kty": "oct", "alg": "A256GCM", "k": ...}
+  ///   print(jsonEncode(jwk));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517

--- a/lib/src/webcrypto/webcrypto.digest.dart
+++ b/lib/src/webcrypto/webcrypto.digest.dart
@@ -42,14 +42,16 @@ abstract final class Hash {
   /// import 'dart:convert' show base64, utf8;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Convert 'hello world' to a byte array
-  /// final bytesToHash = utf8.encode('hello world');
+  /// Future<void> main() async {
+  ///   // Convert 'hello world' to a byte array
+  ///   final bytesToHash = utf8.encode('hello world');
   ///
-  /// // Compute hash of bytesToHash with sha-256
-  /// List<int> hash = await Hash.sha256.digestBytes(bytesToHash);
+  ///   // Compute hash of bytesToHash with sha-256
+  ///   List<int> hash = await Hash.sha256.digestBytes(bytesToHash);
   ///
-  /// // Print the base64 encoded hash
-  /// print(base64.encode(hash));
+  ///   // Print the base64 encoded hash
+  ///   print(base64.encode(hash));
+  /// }
   /// ```
   Future<Uint8List> digestBytes(List<int> data) => _impl.digestBytes(data);
 
@@ -61,20 +63,22 @@ abstract final class Hash {
   /// import 'dart:convert' show base64;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Pick a file to hash.
-  /// String fileToHash = '/etc/passwd';
+  /// Future<void> main() async {
+  ///   // Pick a file to hash.
+  ///   String fileToHash = '/etc/passwd';
   ///
-  /// // Compute hash of fileToHash with sha-256
-  /// List<int> hash;
-  /// final stream = File(fileToHash).openRead();
-  /// try {
-  ///   hash = await Hash.sha256.digestStream(stream);
-  /// } finally {
-  ///   await stream.close(); // always close the stream
+  ///   // Compute hash of fileToHash with sha-256
+  ///   List<int> hash;
+  ///   final stream = File(fileToHash).openRead();
+  ///   try {
+  ///     hash = await Hash.sha256.digestStream(stream);
+  ///   } finally {
+  ///     await stream.close(); // always close the stream
+  ///   }
+  ///
+  ///   // Print the base64 encoded hash
+  ///   print(base64.encode(hash));
   /// }
-  ///
-  /// // Print the base64 encoded hash
-  /// print(base64.encode(hash));
   /// ```
   Future<Uint8List> digestStream(Stream<List<int>> data) =>
       _impl.digestStream(data);
@@ -89,14 +93,16 @@ abstract final class Hash {
   /// import 'dart:convert' show base64, utf8;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Convert 'hello world' to a byte array
-  /// final bytesToHash = utf8.encode('hello world');
+  /// Future<void> main() async {
+  ///   // Convert 'hello world' to a byte array
+  ///   final bytesToHash = utf8.encode('hello world');
   ///
-  /// // Compute hash of bytesToHash with sha-256
-  /// List<int> hash = await Hash.sha256.digestBytes(bytesToHash);
+  ///   // Compute hash of bytesToHash with sha-256
+  ///   List<int> hash = await Hash.sha256.digestBytes(bytesToHash);
   ///
-  /// // Print the base64 encoded hash
-  /// print(base64.encode(hash));
+  ///   // Print the base64 encoded hash
+  ///   print(base64.encode(hash));
+  /// }
   /// ```
   ///
   /// [1]: https://doi.org/10.6028/NIST.FIPS.180-4
@@ -109,14 +115,16 @@ abstract final class Hash {
   /// import 'dart:convert' show base64, utf8;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Convert 'hello world' to a byte array
-  /// final bytesToHash = utf8.encode('hello world');
+  /// Future<void> main() async {
+  ///   // Convert 'hello world' to a byte array
+  ///   final bytesToHash = utf8.encode('hello world');
   ///
-  /// // Compute hash of bytesToHash with sha-256
-  /// List<int> hash = await Hash.sha256.digestBytes(bytesToHash);
+  ///   // Compute hash of bytesToHash with sha-256
+  ///   List<int> hash = await Hash.sha256.digestBytes(bytesToHash);
   ///
-  /// // Print the base64 encoded hash
-  /// print(base64.encode(hash));
+  ///   // Print the base64 encoded hash
+  ///   print(base64.encode(hash));
+  /// }
   /// ```
   ///
   /// [1]: https://doi.org/10.6028/NIST.FIPS.180-4
@@ -129,14 +137,16 @@ abstract final class Hash {
   /// import 'dart:convert' show base64, utf8;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Convert 'hello world' to a byte array
-  /// final bytesToHash = utf8.encode('hello world');
+  /// Future<void> main() async {
+  ///   // Convert 'hello world' to a byte array
+  ///   final bytesToHash = utf8.encode('hello world');
   ///
-  /// // Compute hash of bytesToHash with sha-384
-  /// List<int> hash = await Hash.sha384.digestBytes(bytesToHash);
+  ///   // Compute hash of bytesToHash with sha-384
+  ///   List<int> hash = await Hash.sha384.digestBytes(bytesToHash);
   ///
-  /// // Print the base64 encoded hash
-  /// print(base64.encode(hash));
+  ///   // Print the base64 encoded hash
+  ///   print(base64.encode(hash));
+  /// }
   /// ```
   ///
   /// [1]: https://doi.org/10.6028/NIST.FIPS.180-4
@@ -149,14 +159,16 @@ abstract final class Hash {
   /// import 'dart:convert' show base64, utf8;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Convert 'hello world' to a byte array
-  /// final bytesToHash = utf8.encode('hello world');
+  /// Future<void> main() async {
+  ///   // Convert 'hello world' to a byte array
+  ///   final bytesToHash = utf8.encode('hello world');
   ///
-  /// // Compute hash of bytesToHash with sha-512
-  /// List<int> hash = await Hash.sha512.digestBytes(bytesToHash);
+  ///   // Compute hash of bytesToHash with sha-512
+  ///   List<int> hash = await Hash.sha512.digestBytes(bytesToHash);
   ///
-  /// // Print the base64 encoded hash
-  /// print(base64.encode(hash));
+  ///   // Print the base64 encoded hash
+  ///   print(base64.encode(hash));
+  /// }
   /// ```
   ///
   /// [1]: https://doi.org/10.6028/NIST.FIPS.180-4

--- a/lib/src/webcrypto/webcrypto.hmac.dart
+++ b/lib/src/webcrypto/webcrypto.hmac.dart
@@ -68,10 +68,12 @@ final class HmacSecretKey {
   /// import 'dart:convert' show utf8;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// final key = await HmacSecretKey.importRawKey(
-  ///   base64.decode('WzIxLDg0LDEwMCw5OSwxMCwxMDUsMjIsODAsMTkwLDExNiwyMDMsMjQ5XQ=='),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   final key = await HmacSecretKey.importRawKey(
+  ///     base64.decode('WzIxLDg0LDEwMCw5OSwxMCwxMDUsMjIsODAsMTkwLDExNiwyMDMsMjQ5XQ=='),
+  ///     Hash.sha256,
+  ///   );
+  /// }
   /// ```
   static Future<HmacSecretKey> importRawKey(
     List<int> keyData,
@@ -129,18 +131,20 @@ final class HmacSecretKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode, jsonDecode;
   ///
-  /// // JSON Web Key as a string containing JSON.
-  /// final jwk = '{"kty": "oct", "alg": "HS256", "k": ...}';
+  /// Future<void> main() async {
+  ///   // JSON Web Key as a string containing JSON.
+  ///   final jwk = '{"kty": "oct", "alg": "HS256", "k": ...}';
   ///
-  /// // Import secret key from decoded JSON.
-  /// final key = await HmacSecretKey.importJsonWebKey(
-  ///   jsonDecode(jwk),
-  ///   Hash.sha256, // Must match the hash used the JWK key "alg"
-  /// );
+  ///   // Import secret key from decoded JSON.
+  ///   final key = await HmacSecretKey.importJsonWebKey(
+  ///     jsonDecode(jwk),
+  ///     Hash.sha256, // Must match the hash used the JWK key "alg"
+  ///   );
   ///
-  /// // Export the key (print it in same format as it was given).
-  /// Map<String, dynamic> keyData = await key.exportJsonWebKey();
-  /// print(jsonEncode(keyData));
+  ///   // Export the key (print it in same format as it was given).
+  ///   Map<String, dynamic> keyData = await key.exportJsonWebKey();
+  ///   print(jsonEncode(keyData));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517
@@ -193,8 +197,10 @@ final class HmacSecretKey {
   /// ```dart
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a new random HMAC secret key.
-  /// final key = await HmacSecretKey.generate(Hash.sha256);
+  /// Future<void> main() async {
+  ///   // Generate a new random HMAC secret key.
+  ///   final key = await HmacSecretKey.generate(Hash.sha256);
+  /// }
   /// ```
   static Future<HmacSecretKey> generateKey(Hash hash, {int? length}) async {
     if (length != null && length <= 0) {
@@ -219,16 +225,18 @@ final class HmacSecretKey {
   /// import 'dart:convert' show base64, utf8;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate an HmacSecretKey.
-  /// final key = await HmacSecretKey.generateKey(Hash.sha256);
+  /// Future<void> main() async {
+  ///   // Generate an HmacSecretKey.
+  ///   final key = await HmacSecretKey.generateKey(Hash.sha256);
   ///
-  /// String stringToSign = 'example-string-to-signed';
+  ///   String stringToSign = 'example-string-to-signed';
   ///
-  /// // Compute signature.
-  /// final signature = await key.signBytes(utf8.encode(stringToSign));
+  ///   // Compute signature.
+  ///   final signature = await key.signBytes(utf8.encode(stringToSign));
   ///
-  /// // Print as base64
-  /// print(base64.encode(signature));
+  ///   // Print as base64
+  ///   print(base64.encode(signature));
+  /// }
   /// ```
   ///
   /// {@template HMAC-sign:do-not-validate-using-sign}
@@ -252,18 +260,20 @@ final class HmacSecretKey {
   /// import 'dart:convert' show base64, utf8;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate an HmacSecretKey.
-  /// final key = await HmacSecretKey.generateKey(Hash.sha256);
+  /// Future<void> main() async {
+  ///   // Generate an HmacSecretKey.
+  ///   final key = await HmacSecretKey.generateKey(Hash.sha256);
   ///
-  /// String stringToSign = 'example-string-to-signed';
+  ///   String stringToSign = 'example-string-to-signed';
   ///
-  /// // Compute signature.
-  /// final signature = await key.signStream(Stream.fromIterable([
-  ///   utf8.encode(stringToSign),
-  /// ]));
+  ///   // Compute signature.
+  ///   final signature = await key.signStream(Stream.fromIterable([
+  ///     utf8.encode(stringToSign),
+  ///   ]));
   ///
-  /// // Print as base64
-  /// print(base64.encode(signature));
+  ///   // Print as base64
+  ///   print(base64.encode(signature));
+  /// }
   /// ```
   ///
   /// {@macro HMAC-sign:do-not-validate-using-sign}
@@ -289,20 +299,22 @@ final class HmacSecretKey {
   /// import 'dart:convert' show base64, utf8;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate an HmacSecretKey.
-  /// final key = await HmacSecretKey.generateKey(Hash.sha256);
+  /// Future<void> main() async {
+  ///   // Generate an HmacSecretKey.
+  ///   final key = await HmacSecretKey.generateKey(Hash.sha256);
   ///
-  /// String stringToSign = 'example-string-to-signed';
+  ///   String stringToSign = 'example-string-to-signed';
   ///
-  /// // Compute signature.
-  /// final signature = await key.signBytes(utf8.encode(stringToSign));
+  ///   // Compute signature.
+  ///   final signature = await key.signBytes(utf8.encode(stringToSign));
   ///
-  /// // Verify signature.
-  /// final result = await key.verifyBytes(
-  ///   signature,
-  ///   utf8.encode(stringToSign),
-  /// );
-  /// assert(result == true, 'this signature should be valid');
+  ///   // Verify signature.
+  ///   final result = await key.verifyBytes(
+  ///     signature,
+  ///     utf8.encode(stringToSign),
+  ///   );
+  ///   assert(result == true, 'this signature should be valid');
+  /// }
   /// ```
   Future<bool> verifyBytes(List<int> signature, List<int> data) =>
       _impl.verifyBytes(signature, data);
@@ -320,21 +332,23 @@ final class HmacSecretKey {
   /// import 'dart:convert' show base64, utf8;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate an HmacSecretKey.
-  /// final key = await HmacSecretKey.generateKey(Hash.sha256);
+  /// Future<void> main() async {
+  ///   // Generate an HmacSecretKey.
+  ///   final key = await HmacSecretKey.generateKey(Hash.sha256);
   ///
-  /// String stringToSign = 'example-string-to-signed';
+  ///   String stringToSign = 'example-string-to-signed';
   ///
-  /// // Compute signature.
-  /// final signature = await key.signBytes(Stream.fromIterable([
-  ///   utf8.encode(stringToSign),
-  /// ]));
+  ///   // Compute signature.
+  ///   final signature = await key.signBytes(Stream.fromIterable([
+  ///     utf8.encode(stringToSign),
+  ///   ]));
   ///
-  /// // Verify signature.
-  /// final result = await key.verifyStream(signature, Stream.fromIterable([
-  ///   utf8.encode(stringToSign),
-  /// ]));
-  /// assert(result == true, 'this signature should be valid');
+  ///   // Verify signature.
+  ///   final result = await key.verifyStream(signature, Stream.fromIterable([
+  ///     utf8.encode(stringToSign),
+  ///   ]));
+  ///   assert(result == true, 'this signature should be valid');
+  /// }
   /// ```
   Future<bool> verifyStream(List<int> signature, Stream<List<int>> data) =>
       _impl.verifyStream(signature, data);
@@ -348,17 +362,19 @@ final class HmacSecretKey {
   /// ```dart
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a new random HMAC secret key.
-  /// final key = await HmacSecretKey.generate(Hash.sha256);
+  /// Future<void> main() async {
+  ///   // Generate a new random HMAC secret key.
+  ///   final key = await HmacSecretKey.generate(Hash.sha256);
   ///
-  /// // Extract the secret key.
-  /// final secretBytes = await key.exportRawKey();
+  ///   // Extract the secret key.
+  ///   final secretBytes = await key.exportRawKey();
   ///
-  /// // Print the key as base64
-  /// print(base64.encode(secretBytes));
+  ///   // Print the key as base64
+  ///   print(base64.encode(secretBytes));
   ///
-  /// // If we wanted to we could import the key as follows:
-  /// // key = await HmacSecretKey.importRawKey(secretBytes, Hash.sha256);
+  ///   // If we wanted to we could import the key as follows:
+  ///   // key = await HmacSecretKey.importRawKey(secretBytes, Hash.sha256);
+  /// }
   /// ```
   Future<Uint8List> exportRawKey() => _impl.exportRawKey();
 
@@ -371,16 +387,18 @@ final class HmacSecretKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode;
   ///
-  /// // Generate a new random HMAC secret key.
-  /// final key = await HmacSecretKey.generate(Hash.sha256);
+  /// Future<void> main() async {
+  ///   // Generate a new random HMAC secret key.
+  ///   final key = await HmacSecretKey.generate(Hash.sha256);
   ///
-  /// // Export the secret key.
-  /// final jwk = await key.exportJsonWebKey();
+  ///   // Export the secret key.
+  ///   final jwk = await key.exportJsonWebKey();
   ///
-  /// // The Map returned by `exportJsonWebKey()` can be converted to JSON with
-  /// // `jsonEncode` from `dart:convert`, this will print something like:
-  /// // {"kty": "oct", "alg": "HS256", "k": ...}
-  /// print(jsonEncode(jwk));
+  ///   // The Map returned by `exportJsonWebKey()` can be converted to JSON with
+  ///   // `jsonEncode` from `dart:convert`, this will print something like:
+  ///   // {"kty": "oct", "alg": "HS256", "k": ...}
+  ///   print(jsonEncode(jwk));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517

--- a/lib/src/webcrypto/webcrypto.random.dart
+++ b/lib/src/webcrypto/webcrypto.random.dart
@@ -25,14 +25,16 @@ part of 'webcrypto.dart';
 /// import 'dart:typed_data' show Uint8List;
 /// import 'package:webcrypto/webcrypto.dart';
 ///
-/// // Allocated a byte array of 64 bytes.
-/// final bytes = Uint8List(64);
+/// void main() {
+///   // Allocate a byte array of 64 bytes.
+///   final bytes = Uint8List(64);
 ///
-/// // Fill with random bytes.
-/// fillRandomBytes(bytes);
+///   // Fill with random bytes.
+///   fillRandomBytes(bytes);
 ///
-/// // Print base64 encoded random bytes.
-/// print(base64.encode(bytes));
+///   // Print base64 encoded random bytes.
+///   print(base64.encode(bytes));
+/// }
 /// ```
 void fillRandomBytes(
   TypedData destination,

--- a/lib/src/webcrypto/webcrypto.rsaoaep.dart
+++ b/lib/src/webcrypto/webcrypto.rsaoaep.dart
@@ -33,30 +33,32 @@ part of 'webcrypto.dart';
 /// import 'dart:convert' show utf8;
 /// import 'package:webcrypto/webcrypto.dart';
 ///
-/// // Generate a public / private key-pair.
-/// final keyPair = await RsaOaepPrivateKey.generateKey(
-///   4096,
-///   BigInt.from(65537),
-///   Hash.sha256,
-/// );
+/// Future<void> main() async {
+///   // Generate a public / private key-pair.
+///   final keyPair = await RsaOaepPrivateKey.generateKey(
+///     4096,
+///     BigInt.from(65537),
+///     Hash.sha256,
+///   );
 ///
-/// // Generate a 256 bit symmetric key
-/// final secretKeyToBeShared = await AesGcmSecretKey.generateKey(256);
+///   // Generate a 256 bit symmetric key
+///   final secretKeyToBeShared = await AesGcmSecretKey.generateKey(256);
 ///
-/// // Using publicKey Bob can encrypt secretKeyToBeShared, such that it can
-/// // only be decrypted with the private key.
-/// final encryptedRawKey = await keyPair.publicKey.encryptBytes(
-///   await secretKeyToBeShared.exportRawKey(),
-///   label: 'shared-key',
-/// );
+///   // Using publicKey Bob can encrypt secretKeyToBeShared, such that it can
+///   // only be decrypted with the private key.
+///   final encryptedRawKey = await keyPair.publicKey.encryptBytes(
+///     await secretKeyToBeShared.exportRawKey(),
+///     label: 'shared-key',
+///   );
 ///
-/// // Given privateKey and encryptedRawKey Alice can decrypt the shared key.
-/// final sharedRawSecretKey = await keypair.privateKey.decryptBytes(
-///   encryptedRawKey,
-///   label: 'shared-key',
-/// );
-/// final sharedSecretKey = await AesGcmSecretKey.importRaw(sharedRawSecretKey);
-/// // Now both Alice and Bob share a secret key.
+///   // Given privateKey and encryptedRawKey Alice can decrypt the shared key.
+///   final sharedRawSecretKey = await keyPair.privateKey.decryptBytes(
+///     encryptedRawKey,
+///     label: 'shared-key',
+///   );
+///   final sharedSecretKey = await AesGcmSecretKey.importRaw(sharedRawSecretKey);
+///   // Now both Alice and Bob share a secret key.
+/// }
 /// ```
 /// {@endtemplate}
 ///
@@ -94,23 +96,25 @@ final class RsaOaepPrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Read key data from PEM encoded block. This will remove the
-  /// // '----BEGIN...' padding, decode base64 and return encoded bytes.
-  /// List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
-  ///   -----BEGIN PRIVATE KEY-----
-  ///   MIGEAgEAMBAGByqG...
-  ///   -----END PRIVATE KEY-----
-  /// """);
+  /// Future<void> main() async {
+  ///   // Read key data from PEM encoded block. This will remove the
+  ///   // '----BEGIN...' padding, decode base64 and return encoded bytes.
+  ///   List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
+  ///     -----BEGIN PRIVATE KEY-----
+  ///     MIGEAgEAMBAGByqG...
+  ///     -----END PRIVATE KEY-----
+  ///   """);
   ///
-  /// // Import private key from binary PEM decoded data.
-  /// final privateKey = await RsaOaepPrivateKey.importPkcs8Key(
-  ///   keyData,
-  ///   Hash.sha256,
-  /// );
+  ///   // Import private key from binary PEM decoded data.
+  ///   final privateKey = await RsaOaepPrivateKey.importPkcs8Key(
+  ///     keyData,
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the key again (print it in same format as it was given).
-  /// List<int> rawKeyData = await privateKey.exportPkcs8Key();
-  /// print(PemCodec(PemLabel.privateKey).encode(rawKeyData));
+  ///   // Export the key again (print it in same format as it was given).
+  ///   List<int> rawKeyData = await privateKey.exportPkcs8Key();
+  ///   print(PemCodec(PemLabel.privateKey).encode(rawKeyData));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc5208
@@ -148,18 +152,20 @@ final class RsaOaepPrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode, jsonDecode;
   ///
-  /// // JSON Web Key as a string containing JSON.
-  /// final jwk = '{"kty": "RSA", "alg": "RSA-OAEP-256", ...}';
+  /// Future<void> main() async {
+  ///   // JSON Web Key as a string containing JSON.
+  ///   final jwk = '{"kty": "RSA", "alg": "RSA-OAEP-256", ...}';
   ///
-  /// // Import private key from decoded JSON.
-  /// final privateKey = await RsaOaepPrivateKey.importJsonWebKey(
-  ///   jsonDecode(jwk),
-  ///   Hash.sha256, // Must match the hash used the JWK key "alg"
-  /// );
+  ///   // Import private key from decoded JSON.
+  ///   final privateKey = await RsaOaepPrivateKey.importJsonWebKey(
+  ///     jsonDecode(jwk),
+  ///     Hash.sha256, // Must match the hash used the JWK key "alg"
+  ///   );
   ///
-  /// // Export the key (print it in same format as it was given).
-  /// Map<String, dynamic> keyData = await privateKey.exportJsonWebKey();
-  /// print(jsonEncode(keyData));
+  ///   // Export the key (print it in same format as it was given).
+  ///   Map<String, dynamic> keyData = await privateKey.exportJsonWebKey();
+  ///   print(jsonEncode(keyData));
+  /// }
   /// ```
   ///
   /// {@macro RSA-importJsonWebKey:use-key_ops}
@@ -186,43 +192,45 @@ final class RsaOaepPrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaOaepPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaOaepPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export public, so Bob can use it
-  /// final spkiPublicKey = await keyPair.publicKey.exportSpkiKey();
-  /// final pemPublicKey = PemCodec(PemLabel.publicKey).encode(spkiPublicKey);
-  /// print(pemPublicKey); // print key in PEM format: -----BEGIN PUBLIC KEY....
-  /// // Alice sends pemPublicKey to Bob
+  ///   // Export public, so Bob can use it
+  ///   final spkiPublicKey = await keyPair.publicKey.exportSpkiKey();
+  ///   final pemPublicKey = PemCodec(PemLabel.publicKey).encode(spkiPublicKey);
+  ///   print(pemPublicKey); // print key in PEM format: -----BEGIN PUBLIC KEY....
+  ///   // Alice sends pemPublicKey to Bob
   ///
-  /// // Bob can generate a 256 bit symmetric secret key
-  /// final secretKeyToBeShared = await AesGcmSecretKey.generateKey(256);
+  ///   // Bob can generate a 256 bit symmetric secret key
+  ///   final secretKeyToBeShared = await AesGcmSecretKey.generateKey(256);
   ///
-  /// // Using publicKey Bob can encrypt secretKeyToBeShared, such that it can
-  /// // only be decrypted with the private key.
-  /// final publicKey = RsaOaepPublicKey.importSpki(
-  ///   PemCodec(PemLabel.publicKey).decode(pemPublicKey),
-  ///   Hash.sha256,
-  /// )
-  /// final encryptedRawKey = await publicKey.encryptBytes(
-  ///   await secretKeyToBeShared.exportRawKey(),
-  ///   label: 'shared-key',
-  /// );
-  /// // Bob sends Alice: encryptedRawKey
+  ///   // Using publicKey Bob can encrypt secretKeyToBeShared, such that it can
+  ///   // only be decrypted with the private key.
+  ///   final publicKey = RsaOaepPublicKey.importSpki(
+  ///     PemCodec(PemLabel.publicKey).decode(pemPublicKey),
+  ///     Hash.sha256,
+  ///   )
+  ///   final encryptedRawKey = await publicKey.encryptBytes(
+  ///     await secretKeyToBeShared.exportRawKey(),
+  ///     label: 'shared-key',
+  ///   );
+  ///   // Bob sends Alice: encryptedRawKey
   ///
-  /// // Given privateKey and encryptedRawKey Alice can decrypt the shared key.
-  /// final sharedRawSecretKey = await keypair.privateKey.decryptBytes(
-  ///   encryptedRawKey,
-  ///   label: 'shared-key',
-  /// );
-  /// final sharedSecretKey = await AesGcmSecretKey.importRaw(
-  ///   sharedRawSecretKey,
-  /// );
-  /// // Now both Alice and Bob share a secret key.
+  ///   // Given privateKey and encryptedRawKey Alice can decrypt the shared key.
+  ///   final sharedRawSecretKey = await keyPair.privateKey.decryptBytes(
+  ///     encryptedRawKey,
+  ///     label: 'shared-key',
+  ///   );
+  ///   final sharedSecretKey = await AesGcmSecretKey.importRaw(
+  ///     sharedRawSecretKey,
+  ///   );
+  ///   // Now both Alice and Bob share a secret key.
+  /// }
   /// ```
   static Future<KeyPair<RsaOaepPrivateKey, RsaOaepPublicKey>> generateKey(
     int modulusLength,
@@ -251,32 +259,34 @@ final class RsaOaepPrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaOaepPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
-  /// // Alice sends keyPair.publicKey to Bob
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaOaepPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
+  ///   // Alice sends keyPair.publicKey to Bob
   ///
-  /// // Bob can generate a 256 bit symmetric secret key
-  /// final secretKeyToBeShared = await AesGcmSecretKey.generateKey(256);
+  ///   // Bob can generate a 256 bit symmetric secret key
+  ///   final secretKeyToBeShared = await AesGcmSecretKey.generateKey(256);
   ///
-  /// // Using the public key Bob can encrypt secretKeyToBeShared, such that it
-  /// // can only be decrypted with the private key.
-  /// final encryptedRawKey = await keyPair.publicKey.encryptBytes(
-  ///   await secretKeyToBeShared.exportRawKey(),
-  /// );
-  /// // Bob sends Alice: encryptedRawKey
+  ///   // Using the public key Bob can encrypt secretKeyToBeShared, such that it
+  ///   // can only be decrypted with the private key.
+  ///   final encryptedRawKey = await keyPair.publicKey.encryptBytes(
+  ///     await secretKeyToBeShared.exportRawKey(),
+  ///   );
+  ///   // Bob sends Alice: encryptedRawKey
   ///
-  /// // Given privateKey and encryptedRawKey Alice can decrypt the shared key.
-  /// final sharedRawSecretKey = await keypair.privateKey.decryptBytes(
-  ///   encryptedRawKey,
-  /// );
-  /// final sharedSecretKey = await AesGcmSecretKey.importRaw(
-  ///   sharedRawSecretKey,
-  /// );
-  /// // Now both Alice and Bob share a secret key.
+  ///   // Given privateKey and encryptedRawKey Alice can decrypt the shared key.
+  ///   final sharedRawSecretKey = await keyPair.privateKey.decryptBytes(
+  ///     encryptedRawKey,
+  ///   );
+  ///   final sharedSecretKey = await AesGcmSecretKey.importRaw(
+  ///     sharedRawSecretKey,
+  ///   );
+  ///   // Now both Alice and Bob share a secret key.
+  /// }
   /// ```
   Future<Uint8List> decryptBytes(List<int> data, {List<int>? label}) =>
       _impl.decryptBytes(data, label: label);
@@ -291,20 +301,22 @@ final class RsaOaepPrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaOaepPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaOaepPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the private key.
-  /// final rawPrivateKey = await keypair.privateKey.exportPkcs8Key();
+  ///   // Export the private key.
+  ///   final rawPrivateKey = await keyPair.privateKey.exportPkcs8Key();
   ///
-  /// // Private keys are often encoded as PEM.
-  /// // This encodes the key in base64 and wraps it with:
-  /// // '-----BEGIN PRIVATE KEY----'...
-  /// print(PemCodec(PemLabel.privateKey).encode(rawPrivateKey));
+  ///   // Private keys are often encoded as PEM.
+  ///   // This encodes the key in base64 and wraps it with:
+  ///   // '-----BEGIN PRIVATE KEY----'...
+  ///   print(PemCodec(PemLabel.privateKey).encode(rawPrivateKey));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc5208
@@ -319,20 +331,22 @@ final class RsaOaepPrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode;
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaOaepPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaOaepPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the private key.
-  /// final jwk = await keypair.privateKey.exportJsonWebKey();
+  ///   // Export the private key.
+  ///   final jwk = await keyPair.privateKey.exportJsonWebKey();
   ///
-  /// // The Map returned by `exportJsonWebKey()` can be converted to JSON with
-  /// // `jsonEncode` from `dart:convert`, this will print something like:
-  /// // {"kty": "RSA", "alg": "RSA-OAEP-256", ...}
-  /// print(jsonEncode(jwk));
+  ///   // The Map returned by `exportJsonWebKey()` can be converted to JSON with
+  ///   // `jsonEncode` from `dart:convert`, this will print something like:
+  ///   // {"kty": "RSA", "alg": "RSA-OAEP-256", ...}
+  ///   print(jsonEncode(jwk));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517
@@ -380,23 +394,25 @@ final class RsaOaepPublicKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Read key data from PEM encoded block. This will remove the
-  /// // '----BEGIN...' padding, decode base64 and return encoded bytes.
-  /// List<int> keyData = PemCodec(PemLabel.publicKey).decode("""
-  ///   -----BEGIN PUBLIC KEY-----
-  ///   MIGEAgEAMBAGByqG...
-  ///   -----END PUBLIC KEY-----
-  /// """);
+  /// Future<void> main() async {
+  ///   // Read key data from PEM encoded block. This will remove the
+  ///   // '----BEGIN...' padding, decode base64 and return encoded bytes.
+  ///   List<int> keyData = PemCodec(PemLabel.publicKey).decode("""
+  ///     -----BEGIN PUBLIC KEY-----
+  ///     MIGEAgEAMBAGByqG...
+  ///     -----END PUBLIC KEY-----
+  ///   """);
   ///
-  /// // Import public key from binary PEM decoded data.
-  /// final publicKey = await RsaOaepPublicKey.importSpkiKey(
-  ///   keyData,
-  ///   Hash.sha256,
-  /// );
+  ///   // Import public key from binary PEM decoded data.
+  ///   final publicKey = await RsaOaepPublicKey.importSpkiKey(
+  ///     keyData,
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the key again (print it in same format as it was given).
-  /// List<int> rawKeyData = await publicKey.exportSpkiKey();
-  /// print(PemCodec(PemLabel.publicKey).encode(rawKeyData));
+  ///   // Export the key again (print it in same format as it was given).
+  ///   List<int> rawKeyData = await publicKey.exportSpkiKey();
+  ///   print(PemCodec(PemLabel.publicKey).encode(rawKeyData));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc5280
@@ -428,18 +444,20 @@ final class RsaOaepPublicKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode, jsonDecode;
   ///
-  /// // JSON Web Key as a string containing JSON.
-  /// final jwk = '{"kty": "RSA", "alg": "RSA-OAEP-256", ...}';
+  /// Future<void> main() async {
+  ///   // JSON Web Key as a string containing JSON.
+  ///   final jwk = '{"kty": "RSA", "alg": "RSA-OAEP-256", ...}';
   ///
-  /// // Import public key from decoded JSON.
-  /// final publicKey = await RsaOaepPublicKey.importJsonWebKey(
-  ///   jsonDecode(jwk),
-  ///   Hash.sha256, // Must match the hash used the JWK key "alg"
-  /// );
+  ///   // Import public key from decoded JSON.
+  ///   final publicKey = await RsaOaepPublicKey.importJsonWebKey(
+  ///     jsonDecode(jwk),
+  ///     Hash.sha256, // Must match the hash used the JWK key "alg"
+  ///   );
   ///
-  /// // Export the key (print it in same format as it was given).
-  /// Map<String, dynamic> keyData = await publicKey.exportJsonWebKey();
-  /// print(jsonEncode(keyData));
+  ///   // Export the key (print it in same format as it was given).
+  ///   Map<String, dynamic> keyData = await publicKey.exportJsonWebKey();
+  ///   print(jsonEncode(keyData));
+  /// }
   /// ```
   ///
   /// {@macro RSA-importJsonWebKey:use-key_ops}
@@ -484,34 +502,36 @@ final class RsaOaepPublicKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaOaepPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
-  /// // Alice sends keyPair.publicKey to Bob
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaOaepPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
+  ///   // Alice sends keyPair.publicKey to Bob
   ///
-  /// // Bob can generate a 256 bit symmetric secret key
-  /// final secretKeyToBeShared = await AesGcmSecretKey.generateKey(256);
+  ///   // Bob can generate a 256 bit symmetric secret key
+  ///   final secretKeyToBeShared = await AesGcmSecretKey.generateKey(256);
   ///
-  /// // Using the public key Bob can encrypt secretKeyToBeShared, such that it
-  /// // can only be decrypted with the private key.
-  /// final encryptedRawKey = await keyPair.publicKey.encryptBytes(
-  ///   await secretKeyToBeShared.exportRawKey(),
-  ///   label: 'shared-key-exchange',
-  /// );
-  /// // Bob sends Alice: encryptedRawKey
+  ///   // Using the public key Bob can encrypt secretKeyToBeShared, such that it
+  ///   // can only be decrypted with the private key.
+  ///   final encryptedRawKey = await keyPair.publicKey.encryptBytes(
+  ///     await secretKeyToBeShared.exportRawKey(),
+  ///     label: 'shared-key-exchange',
+  ///   );
+  ///   // Bob sends Alice: encryptedRawKey
   ///
-  /// // Given privateKey and encryptedRawKey Alice can decrypt the shared key.
-  /// final sharedRawSecretKey = await keypair.privateKey.decryptBytes(
-  ///   encryptedRawKey,
-  ///   label: 'shared-key-exchange',
-  /// );
-  /// final sharedSecretKey = await AesGcmSecretKey.importRaw(
-  ///   sharedRawSecretKey,
-  /// );
-  /// // Now both Alice and Bob share a secret key.
+  ///   // Given privateKey and encryptedRawKey Alice can decrypt the shared key.
+  ///   final sharedRawSecretKey = await keyPair.privateKey.decryptBytes(
+  ///     encryptedRawKey,
+  ///     label: 'shared-key-exchange',
+  ///   );
+  ///   final sharedSecretKey = await AesGcmSecretKey.importRaw(
+  ///     sharedRawSecretKey,
+  ///   );
+  ///   // Now both Alice and Bob share a secret key.
+  /// }
   /// ```
   ///
   /// [1]: https://www.shoup.net/papers/iso-2_1.pdf
@@ -535,20 +555,22 @@ final class RsaOaepPublicKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaOaepPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaOaepPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the public key.
-  /// final rawPublicKey = await keyPair.publicKey.exportSpkiKey();
+  ///   // Export the public key.
+  ///   final rawPublicKey = await keyPair.publicKey.exportSpkiKey();
   ///
-  /// // Public keys are often encoded as PEM.
-  /// // This encode the key in base64 and wraps it with:
-  /// // '-----BEGIN PUBLIC KEY-----'...
-  /// print(PemCodec(PemLabel.publicKey).encode(rawPublicKey));
+  ///   // Public keys are often encoded as PEM.
+  ///   // This encode the key in base64 and wraps it with:
+  ///   // '-----BEGIN PUBLIC KEY-----'...
+  ///   print(PemCodec(PemLabel.publicKey).encode(rawPublicKey));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc5280
@@ -563,20 +585,22 @@ final class RsaOaepPublicKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode;
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaOaepPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaOaepPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the public key.
-  /// final jwk = await keypair.publicKey.exportJsonWebKey();
+  ///   // Export the public key.
+  ///   final jwk = await keyPair.publicKey.exportJsonWebKey();
   ///
-  /// // The Map returned by `exportJsonWebKey()` can be converted to JSON with
-  /// // `jsonEncode` from `dart:convert`, this will print something like:
-  /// // {"kty": "RSA", "alg": "RSA-OAEP-256", ...}
-  /// print(jsonEncode(jwk));
+  ///   // The Map returned by `exportJsonWebKey()` can be converted to JSON with
+  ///   // `jsonEncode` from `dart:convert`, this will print something like:
+  ///   // {"kty": "RSA", "alg": "RSA-OAEP-256", ...}
+  ///   print(jsonEncode(jwk));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517

--- a/lib/src/webcrypto/webcrypto.rsapss.dart
+++ b/lib/src/webcrypto/webcrypto.rsapss.dart
@@ -32,31 +32,33 @@ part of 'webcrypto.dart';
 /// import 'dart:convert' show utf8;
 /// import 'package:webcrypto/webcrypto.dart';
 ///
-/// // Generate a key-pair.
-/// final keyPair = await RsaPssPrivateKey.generateKey(
-///   4096,
-///   BigInt.from(65537),
-///   Hash.sha256,
-/// );
+/// Future<void> main() async {
+///   // Generate a key-pair.
+///   final keyPair = await RsaPssPrivateKey.generateKey(
+///     4096,
+///     BigInt.from(65537),
+///     Hash.sha256,
+///   );
 ///
-/// // Use the same saltLength for signing and verifying
-/// const saltLength = 256 / 8;
+///   // Use the same saltLength for signing and verifying
+///   const saltLength = 256 / 8;
 ///
-/// // Using privateKey Bob can sign a message for Alice.
-/// final message = 'Hi Alice';
-/// final signature = await keyPair.privateKey.signBytes(
-///   utf8.encode(message),
-///   saltLength,
-/// );
+///   // Using privateKey Bob can sign a message for Alice.
+///   final message = 'Hi Alice';
+///   final signature = await keyPair.privateKey.signBytes(
+///     utf8.encode(message),
+///     saltLength,
+///   );
 ///
-/// // Given publicKey and signature Alice can verify the message from Bob.
-/// final isValid = await keypair.publicKey.verifyBytes(
-///   signature,
-///   utf8.encode(message),
-///   saltLength,
-/// );
-/// if (isValid) {
-///   print('Authentic message from Bob: $message');
+///   // Given publicKey and signature Alice can verify the message from Bob.
+///   final isValid = await keyPair.publicKey.verifyBytes(
+///     signature,
+///     utf8.encode(message),
+///     saltLength,
+///   );
+///   if (isValid) {
+///     print('Authentic message from Bob: $message');
+///   }
 /// }
 /// ```
 /// {@endtemplate}
@@ -86,23 +88,25 @@ final class RsaPssPrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Read key data from PEM encoded block. This will remove the
-  /// // '----BEGIN...' padding, decode base64 and return encoded bytes.
-  /// List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
-  ///   -----BEGIN PRIVATE KEY-----
-  ///   MIGEAgEAMBAGByqG...
-  ///   -----END PRIVATE KEY-----
-  /// """);
+  /// Future<void> main() async {
+  ///   // Read key data from PEM encoded block. This will remove the
+  ///   // '----BEGIN...' padding, decode base64 and return encoded bytes.
+  ///   List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
+  ///     -----BEGIN PRIVATE KEY-----
+  ///     MIGEAgEAMBAGByqG...
+  ///     -----END PRIVATE KEY-----
+  ///   """);
   ///
-  /// // Import private key from binary PEM decoded data.
-  /// final privateKey = await RsaPssPrivateKey.importPkcs8Key(
-  ///   keyData,
-  ///   Hash.sha256,
-  /// );
+  ///   // Import private key from binary PEM decoded data.
+  ///   final privateKey = await RsaPssPrivateKey.importPkcs8Key(
+  ///     keyData,
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the key again (print it in same format as it was given).
-  /// List<int> rawKeyData = await privateKey.exportPkcs8Key();
-  /// print(PemCodec(PemLabel.privateKey).encode(rawKeyData));
+  ///   // Export the key again (print it in same format as it was given).
+  ///   List<int> rawKeyData = await privateKey.exportPkcs8Key();
+  ///   print(PemCodec(PemLabel.privateKey).encode(rawKeyData));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc5208
@@ -140,18 +144,20 @@ final class RsaPssPrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode, jsonDecode;
   ///
-  /// // JSON Web Key as a string containing JSON.
-  /// final jwk = '{"kty": "RSA", "alg": "PS256", ...}';
+  /// Future<void> main() async {
+  ///   // JSON Web Key as a string containing JSON.
+  ///   final jwk = '{"kty": "RSA", "alg": "PS256", ...}';
   ///
-  /// // Import private key from decoded JSON.
-  /// final privateKey = await RsaPssPrivateKey.importJsonWebKey(
-  ///   jsonDecode(jwk),
-  ///   Hash.sha256, // Must match the hash used the JWK key "alg"
-  /// );
+  ///   // Import private key from decoded JSON.
+  ///   final privateKey = await RsaPssPrivateKey.importJsonWebKey(
+  ///     jsonDecode(jwk),
+  ///     Hash.sha256, // Must match the hash used the JWK key "alg"
+  ///   );
   ///
-  /// // Export the key (print it in same format as it was given).
-  /// Map<String, dynamic> keyData = await privateKey.exportJsonWebKey();
-  /// print(jsonEncode(keyData));
+  ///   // Export the key (print it in same format as it was given).
+  ///   Map<String, dynamic> keyData = await privateKey.exportJsonWebKey();
+  ///   print(jsonEncode(keyData));
+  /// }
   /// ```
   ///
   /// {@macro RSA-importJsonWebKey:use-key_ops}
@@ -178,42 +184,44 @@ final class RsaPssPrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaPssPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaPssPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export public, so Alice can use it later.
-  /// final spkiPublicKey = await keyPair.publicKey.exportSpkiKey();
-  /// final pemPublicKey = PemCodec(PemLabel.publicKey).encode(spkiPublicKey);
-  /// print(pemPublicKey); // print key in PEM format: -----BEGIN PUBLIC KEY....
+  ///   // Export public, so Alice can use it later.
+  ///   final spkiPublicKey = await keyPair.publicKey.exportSpkiKey();
+  ///   final pemPublicKey = PemCodec(PemLabel.publicKey).encode(spkiPublicKey);
+  ///   print(pemPublicKey); // print key in PEM format: -----BEGIN PUBLIC KEY....
   ///
-  /// // Use the same saltLength for signing and verifying
-  /// const saltLength = 256 / 8;
+  ///   // Use the same saltLength for signing and verifying
+  ///   const saltLength = 256 / 8;
   ///
-  /// // Sign a message for Alice.
-  /// final message = 'Hi Alice';
-  /// final signature = await keyPair.privateKey.signBytes(
-  ///   utf8.encode(message),
-  ///   saltLength,
-  /// );
+  ///   // Sign a message for Alice.
+  ///   final message = 'Hi Alice';
+  ///   final signature = await keyPair.privateKey.signBytes(
+  ///     utf8.encode(message),
+  ///     saltLength,
+  ///   );
   ///
-  /// // On the other side of the world, Alice has written down the pemPublicKey
-  /// // on a trusted piece of paper, but receives the message and signature
-  /// // from an untrusted source (thus, desires to verify the signature).
-  /// final publicKey = await RsaPssPublicKey.importSpkiKey(
-  ///   PemCodec(PemLabel.publicKey).decode(pemPublicKey),
-  ///   Hash.sha256,
-  /// );
-  /// final isValid = await publicKey.verifyBytes(
-  ///   signature,
-  ///   utf8.encode(message),
-  ///   saltLength,
-  /// );
-  /// if (isValid) {
-  ///   print('Authentic message from Bob: $message');
+  ///   // On the other side of the world, Alice has written down the pemPublicKey
+  ///   // on a trusted piece of paper, but receives the message and signature
+  ///   // from an untrusted source (thus, desires to verify the signature).
+  ///   final publicKey = await RsaPssPublicKey.importSpkiKey(
+  ///     PemCodec(PemLabel.publicKey).decode(pemPublicKey),
+  ///     Hash.sha256,
+  ///   );
+  ///   final isValid = await publicKey.verifyBytes(
+  ///     signature,
+  ///     utf8.encode(message),
+  ///     saltLength,
+  ///   );
+  ///   if (isValid) {
+  ///     print('Authentic message from Bob: $message');
+  ///   }
   /// }
   /// ```
   static Future<KeyPair<RsaPssPrivateKey, RsaPssPublicKey>> generateKey(
@@ -251,33 +259,35 @@ final class RsaPssPrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Read prviate key data from PEM encoded block. This will remove the
-  /// // '----BEGIN...' padding, decode base64 and return encoded bytes.
-  /// List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
-  ///   -----BEGIN PRIVATE KEY-----
-  ///   MIGEAgEAMBAGByqG...
-  ///   -----END PRIVATE KEY-----
-  /// """);
+  /// Future<void> main() async {
+  ///   // Read prviate key data from PEM encoded block. This will remove the
+  ///   // '----BEGIN...' padding, decode base64 and return encoded bytes.
+  ///   List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
+  ///     -----BEGIN PRIVATE KEY-----
+  ///     MIGEAgEAMBAGByqG...
+  ///     -----END PRIVATE KEY-----
+  ///   """);
   ///
-  /// // Import private key from binary PEM decoded data.
-  /// final privatKey = await RsaPssPrivateKey.importPkcs8Key(
-  ///   keyData,
-  ///   Hash.sha256,
-  /// );
+  ///   // Import private key from binary PEM decoded data.
+  ///   final privatKey = await RsaPssPrivateKey.importPkcs8Key(
+  ///     keyData,
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Use the same salt for signing and verifying.
-  /// // In this case we're using the length of the hash function, divided by 8
-  /// // to as saltLength must be specified in bytes.
-  /// const saltLength = 256 / 8;
+  ///   // Use the same salt for signing and verifying.
+  ///   // In this case we're using the length of the hash function, divided by 8
+  ///   // to as saltLength must be specified in bytes.
+  ///   const saltLength = 256 / 8;
   ///
-  /// // Create a signature for UTF-8 encoded message
-  /// final message = 'hello world';
-  /// final signature = await privateKey.signBytes(
-  ///   utf8.encode(message),
-  ///   saltLength,
-  /// );
+  ///   // Create a signature for UTF-8 encoded message
+  ///   final message = 'hello world';
+  ///   final signature = await privateKey.signBytes(
+  ///     utf8.encode(message),
+  ///     saltLength,
+  ///   );
   ///
-  /// print('signature: ${base64.encode(signature)}');
+  ///   print('signature: ${base64.encode(signature)}');
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc3447#section-9.1
@@ -326,32 +336,34 @@ final class RsaPssPrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Read prviate key data from PEM encoded block. This will remove the
-  /// // '----BEGIN...' padding, decode base64 and return encoded bytes.
-  /// List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
-  ///   -----BEGIN PRIVATE KEY-----
-  ///   MIGEAgEAMBAGByqG...
-  ///   -----END PRIVATE KEY-----
-  /// """);
+  /// Future<void> main() async {
+  ///   // Read prviate key data from PEM encoded block. This will remove the
+  ///   // '----BEGIN...' padding, decode base64 and return encoded bytes.
+  ///   List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
+  ///     -----BEGIN PRIVATE KEY-----
+  ///     MIGEAgEAMBAGByqG...
+  ///     -----END PRIVATE KEY-----
+  ///   """);
   ///
-  /// // Import private key from binary PEM decoded data.
-  /// final privatKey = await RsaPssPrivateKey.importPkcs8Key(
-  ///   keyData,
-  ///   Hash.sha256,
-  /// );
+  ///   // Import private key from binary PEM decoded data.
+  ///   final privatKey = await RsaPssPrivateKey.importPkcs8Key(
+  ///     keyData,
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Use the same salt for signing and verifying.
-  /// // In this case we're using the length of the hash function, divided by 8
-  /// // to as saltLength must be specified in bytes.
-  /// const saltLength = 256 / 8;
+  ///   // Use the same salt for signing and verifying.
+  ///   // In this case we're using the length of the hash function, divided by 8
+  ///   // to as saltLength must be specified in bytes.
+  ///   const saltLength = 256 / 8;
   ///
-  /// // Create a signature for message read directly from file.
-  /// final signature = await privateKey.signStream(
-  ///   File('message.txt').openRead(),
-  ///   saltLength,
-  /// );
+  ///   // Create a signature for message read directly from file.
+  ///   final signature = await privateKey.signStream(
+  ///     File('message.txt').openRead(),
+  ///     saltLength,
+  ///   );
   ///
-  /// print('signature: ${base64.encode(signature)}');
+  ///   print('signature: ${base64.encode(signature)}');
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc3447#section-9.1
@@ -369,20 +381,22 @@ final class RsaPssPrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaPssPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaPssPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the private key.
-  /// final rawPrivateKey = await keypair.privateKey.exportPkcs8Key();
+  ///   // Export the private key.
+  ///   final rawPrivateKey = await keyPair.privateKey.exportPkcs8Key();
   ///
-  /// // Private keys are often encoded as PEM.
-  /// // This encodes the key in base64 and wraps it with:
-  /// // '-----BEGIN PRIVATE KEY----'...
-  /// print(PemCodec(PemLabel.privateKey).encode(rawPrivateKey));
+  ///   // Private keys are often encoded as PEM.
+  ///   // This encodes the key in base64 and wraps it with:
+  ///   // '-----BEGIN PRIVATE KEY----'...
+  ///   print(PemCodec(PemLabel.privateKey).encode(rawPrivateKey));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc5208
@@ -397,20 +411,22 @@ final class RsaPssPrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode;
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaPssPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaPssPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the private key.
-  /// final jwk = await keypair.privateKey.exportJsonWebKey();
+  ///   // Export the private key.
+  ///   final jwk = await keyPair.privateKey.exportJsonWebKey();
   ///
-  /// // The Map returned by `exportJsonWebKey()` can be converted to JSON with
-  /// // `jsonEncode` from `dart:convert`, this will print something like:
-  /// // {"kty": "RSA", "alg": "PS256", ...}
-  /// print(jsonEncode(jwk));
+  ///   // The Map returned by `exportJsonWebKey()` can be converted to JSON with
+  ///   // `jsonEncode` from `dart:convert`, this will print something like:
+  ///   // {"kty": "RSA", "alg": "PS256", ...}
+  ///   print(jsonEncode(jwk));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517
@@ -456,23 +472,25 @@ final class RsaPssPublicKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Read key data from PEM encoded block. This will remove the
-  /// // '----BEGIN...' padding, decode base64 and return encoded bytes.
-  /// List<int> keyData = PemCodec(PemLabel.publicKey).decode("""
-  ///   -----BEGIN PUBLIC KEY-----
-  ///   MIGEAgEAMBAGByqG...
-  ///   -----END PUBLIC KEY-----
-  /// """);
+  /// Future<void> main() async {
+  ///   // Read key data from PEM encoded block. This will remove the
+  ///   // '----BEGIN...' padding, decode base64 and return encoded bytes.
+  ///   List<int> keyData = PemCodec(PemLabel.publicKey).decode("""
+  ///     -----BEGIN PUBLIC KEY-----
+  ///     MIGEAgEAMBAGByqG...
+  ///     -----END PUBLIC KEY-----
+  ///   """);
   ///
-  /// // Import public key from binary PEM decoded data.
-  /// final publicKey = await RsaPssPublicKey.importSpkiKey(
-  ///   keyData,
-  ///   Hash.sha256,
-  /// );
+  ///   // Import public key from binary PEM decoded data.
+  ///   final publicKey = await RsaPssPublicKey.importSpkiKey(
+  ///     keyData,
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the key again (print it in same format as it was given).
-  /// List<int> rawKeyData = await publicKey.exportSpkiKey();
-  /// print(PemCodec(PemLabel.publicKey).encode(rawKeyData));
+  ///   // Export the key again (print it in same format as it was given).
+  ///   List<int> rawKeyData = await publicKey.exportSpkiKey();
+  ///   print(PemCodec(PemLabel.publicKey).encode(rawKeyData));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc5280
@@ -504,18 +522,20 @@ final class RsaPssPublicKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode, jsonDecode;
   ///
-  /// // JSON Web Key as a string containing JSON.
-  /// final jwk = '{"kty": "RSA", "alg": "PS256", ...}';
+  /// Future<void> main() async {
+  ///   // JSON Web Key as a string containing JSON.
+  ///   final jwk = '{"kty": "RSA", "alg": "PS256", ...}';
   ///
-  /// // Import public key from decoded JSON.
-  /// final publicKey = await RsaPssPublicKey.importJsonWebKey(
-  ///   jsonDecode(jwk),
-  ///   Hash.sha256, // Must match the hash used the JWK key "alg"
-  /// );
+  ///   // Import public key from decoded JSON.
+  ///   final publicKey = await RsaPssPublicKey.importJsonWebKey(
+  ///     jsonDecode(jwk),
+  ///     Hash.sha256, // Must match the hash used the JWK key "alg"
+  ///   );
   ///
-  /// // Export the key (print it in same format as it was given).
-  /// Map<String, dynamic> keyData = await publicKey.exportJsonWebKey();
-  /// print(jsonEncode(keyData));
+  ///   // Export the key (print it in same format as it was given).
+  ///   Map<String, dynamic> keyData = await publicKey.exportJsonWebKey();
+  ///   print(jsonEncode(keyData));
+  /// }
   /// ```
   ///
   /// {@macro RSA-importJsonWebKey:use-key_ops}
@@ -546,31 +566,33 @@ final class RsaPssPublicKey {
   /// import 'dart:convert' show utf8;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaPssPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaPssPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Use the same salt for signing and verifying.
-  /// const saltLength = 256 / 8;
+  ///   // Use the same salt for signing and verifying.
+  ///   const saltLength = 256 / 8;
   ///
-  /// // Using privateKey Bob can sign a message for Alice.
-  /// final message = 'Hi Alice';
-  /// final signature = await keyPair.privateKey.signBytes(
-  ///   utf8.encode(message),
-  ///   saltLength,
-  /// );
+  ///   // Using privateKey Bob can sign a message for Alice.
+  ///   final message = 'Hi Alice';
+  ///   final signature = await keyPair.privateKey.signBytes(
+  ///     utf8.encode(message),
+  ///     saltLength,
+  ///   );
   ///
-  /// // Given publicKey and signature Alice can verify the message from Bob.
-  /// final isValid = await keypair.publicKey.verifyBytes(
-  ///   signature,
-  ///   utf8.encode(message),
-  ///   saltLength,
-  /// );
-  /// if (isValid) {
-  ///   print('Authentic message from Bob: $message');
+  ///   // Given publicKey and signature Alice can verify the message from Bob.
+  ///   final isValid = await keyPair.publicKey.verifyBytes(
+  ///     signature,
+  ///     utf8.encode(message),
+  ///     saltLength,
+  ///   );
+  ///   if (isValid) {
+  ///     print('Authentic message from Bob: $message');
+  ///   }
   /// }
   /// ```
   Future<bool> verifyBytes(
@@ -593,30 +615,32 @@ final class RsaPssPublicKey {
   /// import 'dart:io' show File;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaPssPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaPssPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Use the same salt for signing and verifying.
-  /// const saltLength = 256 / 8;
+  ///   // Use the same salt for signing and verifying.
+  ///   const saltLength = 256 / 8;
   ///
-  /// // Using privateKey Bob can sign a message for Alice.
-  /// final signature = await keyPair.privateKey.signStream(
-  ///   File('message.txt').openRead(), // read directly from file
-  ///   saltLength,
-  /// );
+  ///   // Using privateKey Bob can sign a message for Alice.
+  ///   final signature = await keyPair.privateKey.signStream(
+  ///     File('message.txt').openRead(), // read directly from file
+  ///     saltLength,
+  ///   );
   ///
-  /// // Given publicKey and signature Alice can verify the message from Bob.
-  /// final isValid = await keypair.publicKey.verifyStream(
-  ///   signature,
-  ///   File('message.txt').openRead(), // read directly from file
-  ///   saltLength,
-  /// );
-  /// if (isValid) {
-  ///   print('Authentic message from Bob: $message');
+  ///   // Given publicKey and signature Alice can verify the message from Bob.
+  ///   final isValid = await keyPair.publicKey.verifyStream(
+  ///     signature,
+  ///     File('message.txt').openRead(), // read directly from file
+  ///     saltLength,
+  ///   );
+  ///   if (isValid) {
+  ///     print('Authentic message from Bob: $message');
+  ///   }
   /// }
   /// ```
   Future<bool> verifyStream(
@@ -635,20 +659,22 @@ final class RsaPssPublicKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaPssPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaPssPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the public key.
-  /// final rawPublicKey = await keyPair.publicKey.exportSpkiKey();
+  ///   // Export the public key.
+  ///   final rawPublicKey = await keyPair.publicKey.exportSpkiKey();
   ///
-  /// // Public keys are often encoded as PEM.
-  /// // This encode the key in base64 and wraps it with:
-  /// // '-----BEGIN PUBLIC KEY-----'...
-  /// print(PemCodec(PemLabel.publicKey).encode(rawPublicKey));
+  ///   // Public keys are often encoded as PEM.
+  ///   // This encode the key in base64 and wraps it with:
+  ///   // '-----BEGIN PUBLIC KEY-----'...
+  ///   print(PemCodec(PemLabel.publicKey).encode(rawPublicKey));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc5280
@@ -663,20 +689,22 @@ final class RsaPssPublicKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode;
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsaPssPrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsaPssPrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the public key.
-  /// final jwk = await keypair.publicKey.exportJsonWebKey();
+  ///   // Export the public key.
+  ///   final jwk = await keyPair.publicKey.exportJsonWebKey();
   ///
-  /// // The Map returned by `exportJsonWebKey()` can be converted to JSON with
-  /// // `jsonEncode` from `dart:convert`, this will print something like:
-  /// // {"kty": "RSA", "alg": "PS256", ...}
-  /// print(jsonEncode(jwk));
+  ///   // The Map returned by `exportJsonWebKey()` can be converted to JSON with
+  ///   // `jsonEncode` from `dart:convert`, this will print something like:
+  ///   // {"kty": "RSA", "alg": "PS256", ...}
+  ///   print(jsonEncode(jwk));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517

--- a/lib/src/webcrypto/webcrypto.rsassapkcs1v15.dart
+++ b/lib/src/webcrypto/webcrypto.rsassapkcs1v15.dart
@@ -33,24 +33,26 @@ part of 'webcrypto.dart';
 /// import 'dart:convert' show utf8;
 /// import 'package:webcrypto/webcrypto.dart';
 ///
-/// // Generate a key-pair.
-/// final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
-///   4096,
-///   BigInt.from(65537),
-///   Hash.sha256,
-/// );
+/// Future<void> main() async {
+///   // Generate a key-pair.
+///   final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
+///     4096,
+///     BigInt.from(65537),
+///     Hash.sha256,
+///   );
 ///
-/// // Using privateKey Bob can sign a message for Alice.
-/// final message = 'Hi Alice';
-/// final signature = await keyPair.privateKey.signBytes(utf8.encode(message));
+///   // Using privateKey Bob can sign a message for Alice.
+///   final message = 'Hi Alice';
+///   final signature = await keyPair.privateKey.signBytes(utf8.encode(message));
 ///
-/// // Given publicKey and signature Alice can verify the message from Bob.
-/// final isValid = await keypair.publicKey.verifyBytes(
-///   signature,
-///   utf8.encode(message),
-/// );
-/// if (isValid) {
-///   print('Authentic message from Bob: $message');
+///   // Given publicKey and signature Alice can verify the message from Bob.
+///   final isValid = await keyPair.publicKey.verifyBytes(
+///     signature,
+///     utf8.encode(message),
+///   );
+///   if (isValid) {
+///     print('Authentic message from Bob: $message');
+///   }
 /// }
 /// ```
 /// {@endtemplate}
@@ -82,23 +84,25 @@ final class RsassaPkcs1V15PrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Read key data from PEM encoded block. This will remove the
-  /// // '----BEGIN...' padding, decode base64 and return encoded bytes.
-  /// List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
-  ///   -----BEGIN PRIVATE KEY-----
-  ///   MIGEAgEAMBAGByqG...
-  ///   -----END PRIVATE KEY-----
-  /// """);
+  /// Future<void> main() async {
+  ///   // Read key data from PEM encoded block. This will remove the
+  ///   // '----BEGIN...' padding, decode base64 and return encoded bytes.
+  ///   List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
+  ///     -----BEGIN PRIVATE KEY-----
+  ///     MIGEAgEAMBAGByqG...
+  ///     -----END PRIVATE KEY-----
+  ///   """);
   ///
-  /// // Import private key from binary PEM decoded data.
-  /// final privateKey = await RsassaPkcs1V15PrivateKey.importPkcs8Key(
-  ///   keyData,
-  ///   Hash.sha256,
-  /// );
+  ///   // Import private key from binary PEM decoded data.
+  ///   final privateKey = await RsassaPkcs1V15PrivateKey.importPkcs8Key(
+  ///     keyData,
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the key again (print it in same format as it was given).
-  /// List<int> rawKeyData = await privateKey.exportPkcs8Key();
-  /// print(PemCodec(PemLabel.privateKey).encode(rawKeyData));
+  ///   // Export the key again (print it in same format as it was given).
+  ///   List<int> rawKeyData = await privateKey.exportPkcs8Key();
+  ///   print(PemCodec(PemLabel.privateKey).encode(rawKeyData));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc5208
@@ -142,18 +146,20 @@ final class RsassaPkcs1V15PrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode, jsonDecode;
   ///
-  /// // JSON Web Key as a string containing JSON.
-  /// final jwk = '{"kty": "RSA", "alg": "RS256", ...}';
+  /// Future<void> main() async {
+  ///   // JSON Web Key as a string containing JSON.
+  ///   final jwk = '{"kty": "RSA", "alg": "RS256", ...}';
   ///
-  /// // Import private key from decoded JSON.
-  /// final privateKey = await RsassaPkcs1V15PrivateKey.importJsonWebKey(
-  ///   jsonDecode(jwk),
-  ///   Hash.sha256, // Must match the hash used the JWK key "alg"
-  /// );
+  ///   // Import private key from decoded JSON.
+  ///   final privateKey = await RsassaPkcs1V15PrivateKey.importJsonWebKey(
+  ///     jsonDecode(jwk),
+  ///     Hash.sha256, // Must match the hash used the JWK key "alg"
+  ///   );
   ///
-  /// // Export the key (print it in same format as it was given).
-  /// Map<String, dynamic> keyData = await privateKey.exportJsonWebKey();
-  /// print(jsonEncode(keyData));
+  ///   // Export the key (print it in same format as it was given).
+  ///   Map<String, dynamic> keyData = await privateKey.exportJsonWebKey();
+  ///   print(jsonEncode(keyData));
+  /// }
   /// ```
   ///
   /// {@template RSA-importJsonWebKey:use-key_ops}
@@ -214,37 +220,39 @@ final class RsassaPkcs1V15PrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export public, so Alice can use it later.
-  /// final spkiPublicKey = await keyPair.publicKey.exportSpkiKey();
-  /// final pemPublicKey = PemCodec(PemLabel.publicKey).encode(spkiPublicKey);
-  /// print(pemPublicKey); // print key in PEM format: -----BEGIN PUBLIC KEY....
+  ///   // Export public, so Alice can use it later.
+  ///   final spkiPublicKey = await keyPair.publicKey.exportSpkiKey();
+  ///   final pemPublicKey = PemCodec(PemLabel.publicKey).encode(spkiPublicKey);
+  ///   print(pemPublicKey); // print key in PEM format: -----BEGIN PUBLIC KEY....
   ///
-  /// // Sign a message for Alice.
-  /// final message = 'Hi Alice';
-  /// final signature = await keyPair.privateKey.signBytes(
-  ///   utf8.encode(message),
-  /// );
+  ///   // Sign a message for Alice.
+  ///   final message = 'Hi Alice';
+  ///   final signature = await keyPair.privateKey.signBytes(
+  ///     utf8.encode(message),
+  ///   );
   ///
-  /// // On the other side of the world, Alice has written down the pemPublicKey
-  /// // on a trusted piece of paper, but receives the message and signature
-  /// // from an untrusted source (thus, desires to verify the signature).
-  /// final publicKey = await RsassaPkcs1V15PublicKey.importSpkiKey(
-  ///   PemCodec(PemLabel.publicKey).decode(pemPublicKey),
-  ///   Hash.sha256,
-  /// );
-  /// final isValid = await publicKey.verifyBytes(
-  ///   signature,
-  ///   utf8.encode(message),
-  /// );
-  /// if (isValid) {
-  ///   print('Authentic message from Bob: $message');
+  ///   // On the other side of the world, Alice has written down the pemPublicKey
+  ///   // on a trusted piece of paper, but receives the message and signature
+  ///   // from an untrusted source (thus, desires to verify the signature).
+  ///   final publicKey = await RsassaPkcs1V15PublicKey.importSpkiKey(
+  ///     PemCodec(PemLabel.publicKey).decode(pemPublicKey),
+  ///     Hash.sha256,
+  ///   );
+  ///   final isValid = await publicKey.verifyBytes(
+  ///     signature,
+  ///     utf8.encode(message),
+  ///   );
+  ///   if (isValid) {
+  ///     print('Authentic message from Bob: $message');
+  ///   }
   /// }
   /// ```
   static Future<KeyPair<RsassaPkcs1V15PrivateKey, RsassaPkcs1V15PublicKey>>
@@ -270,25 +278,27 @@ final class RsassaPkcs1V15PrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Read prviate key data from PEM encoded block. This will remove the
-  /// // '----BEGIN...' padding, decode base64 and return encoded bytes.
-  /// List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
-  ///   -----BEGIN PRIVATE KEY-----
-  ///   MIGEAgEAMBAGByqG...
-  ///   -----END PRIVATE KEY-----
-  /// """);
+  /// Future<void> main() async {
+  ///   // Read prviate key data from PEM encoded block. This will remove the
+  ///   // '----BEGIN...' padding, decode base64 and return encoded bytes.
+  ///   List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
+  ///     -----BEGIN PRIVATE KEY-----
+  ///     MIGEAgEAMBAGByqG...
+  ///     -----END PRIVATE KEY-----
+  ///   """);
   ///
-  /// // Import private key from binary PEM decoded data.
-  /// final privatKey = await RsassaPkcs1V15PrivateKey.importPkcs8Key(
-  ///   keyData,
-  ///   Hash.sha256,
-  /// );
+  ///   // Import private key from binary PEM decoded data.
+  ///   final privatKey = await RsassaPkcs1V15PrivateKey.importPkcs8Key(
+  ///     keyData,
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Create a signature for UTF-8 encoded message
-  /// final message = 'hello world';
-  /// final signature = await privateKey.signBytes(utf8.encode(message));
+  ///   // Create a signature for UTF-8 encoded message
+  ///   final message = 'hello world';
+  ///   final signature = await privateKey.signBytes(utf8.encode(message));
   ///
-  /// print('signature: ${base64.encode(signature)}');
+  ///   print('signature: ${base64.encode(signature)}');
+  /// }
   /// ```
   Future<Uint8List> signBytes(List<int> data) => _impl.signBytes(data);
 
@@ -303,27 +313,29 @@ final class RsassaPkcs1V15PrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Read prviate key data from PEM encoded block. This will remove the
-  /// // '----BEGIN...' padding, decode base64 and return encoded bytes.
-  /// List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
-  ///   -----BEGIN PRIVATE KEY-----
-  ///   MIGEAgEAMBAGByqG...
-  ///   -----END PRIVATE KEY-----
-  /// """);
+  /// Future<void> main() async {
+  ///   // Read prviate key data from PEM encoded block. This will remove the
+  ///   // '----BEGIN...' padding, decode base64 and return encoded bytes.
+  ///   List<int> keyData = PemCodec(PemLabel.privateKey).decode("""
+  ///     -----BEGIN PRIVATE KEY-----
+  ///     MIGEAgEAMBAGByqG...
+  ///     -----END PRIVATE KEY-----
+  ///   """);
   ///
-  /// // Import private key from binary PEM decoded data.
-  /// final privatKey = await RsassaPkcs1V15PrivateKey.importPkcs8Key(
-  ///   keyData,
-  ///   Hash.sha256,
-  /// );
+  ///   // Import private key from binary PEM decoded data.
+  ///   final privatKey = await RsassaPkcs1V15PrivateKey.importPkcs8Key(
+  ///     keyData,
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Create a signature for UTF-8 encoded message
-  /// final message = 'hello world';
-  /// final signature = await privateKey.signStream(Stream.fromIterable([
-  ///   utf8.encode(message),
-  /// ]));
+  ///   // Create a signature for UTF-8 encoded message
+  ///   final message = 'hello world';
+  ///   final signature = await privateKey.signStream(Stream.fromIterable([
+  ///     utf8.encode(message),
+  ///   ]));
   ///
-  /// print('signature: ${base64.encode(signature)}');
+  ///   print('signature: ${base64.encode(signature)}');
+  /// }
   /// ```
   Future<Uint8List> signStream(Stream<List<int>> data) =>
       _impl.signStream(data);
@@ -338,20 +350,22 @@ final class RsassaPkcs1V15PrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the private key.
-  /// final rawPrivateKey = await keypair.privateKey.exportPkcs8Key();
+  ///   // Export the private key.
+  ///   final rawPrivateKey = await keyPair.privateKey.exportPkcs8Key();
   ///
-  /// // Private keys are often encoded as PEM.
-  /// // This encodes the key in base64 and wraps it with:
-  /// // '-----BEGIN PRIVATE KEY----'...
-  /// print(PemCodec(PemLabel.privateKey).encode(rawPrivateKey));
+  ///   // Private keys are often encoded as PEM.
+  ///   // This encodes the key in base64 and wraps it with:
+  ///   // '-----BEGIN PRIVATE KEY----'...
+  ///   print(PemCodec(PemLabel.privateKey).encode(rawPrivateKey));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc5208
@@ -369,20 +383,22 @@ final class RsassaPkcs1V15PrivateKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode;
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the private key.
-  /// final jwk = await keypair.privateKey.exportJsonWebKey();
+  ///   // Export the private key.
+  ///   final jwk = await keyPair.privateKey.exportJsonWebKey();
   ///
-  /// // The Map returned by `exportJsonWebKey()` can be converted to JSON with
-  /// // `jsonEncode` from `dart:convert`, this will print something like:
-  /// // {"kty": "RSA", "alg": "RS256", ...}
-  /// print(jsonEncode(jwk));
+  ///   // The Map returned by `exportJsonWebKey()` can be converted to JSON with
+  ///   // `jsonEncode` from `dart:convert`, this will print something like:
+  ///   // {"kty": "RSA", "alg": "RS256", ...}
+  ///   print(jsonEncode(jwk));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517
@@ -430,23 +446,25 @@ final class RsassaPkcs1V15PublicKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Read key data from PEM encoded block. This will remove the
-  /// // '----BEGIN...' padding, decode base64 and return encoded bytes.
-  /// List<int> keyData = PemCodec(PemLabel.publicKey).decode("""
-  ///   -----BEGIN PUBLIC KEY-----
-  ///   MIGEAgEAMBAGByqG...
-  ///   -----END PUBLIC KEY-----
-  /// """);
+  /// Future<void> main() async {
+  ///   // Read key data from PEM encoded block. This will remove the
+  ///   // '----BEGIN...' padding, decode base64 and return encoded bytes.
+  ///   List<int> keyData = PemCodec(PemLabel.publicKey).decode("""
+  ///     -----BEGIN PUBLIC KEY-----
+  ///     MIGEAgEAMBAGByqG...
+  ///     -----END PUBLIC KEY-----
+  ///   """);
   ///
-  /// // Import public key from binary PEM decoded data.
-  /// final publicKey = await RsassaPkcs1V15PublicKey.importSpkiKey(
-  ///   keyData,
-  ///   Hash.sha256,
-  /// );
+  ///   // Import public key from binary PEM decoded data.
+  ///   final publicKey = await RsassaPkcs1V15PublicKey.importSpkiKey(
+  ///     keyData,
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the key again (print it in same format as it was given).
-  /// List<int> rawKeyData = await publicKey.exportSpkiKey();
-  /// print(PemCodec(PemLabel.publicKey).encode(rawKeyData));
+  ///   // Export the key again (print it in same format as it was given).
+  ///   List<int> rawKeyData = await publicKey.exportSpkiKey();
+  ///   print(PemCodec(PemLabel.publicKey).encode(rawKeyData));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc5280
@@ -478,18 +496,20 @@ final class RsassaPkcs1V15PublicKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode, jsonDecode;
   ///
-  /// // JSON Web Key as a string containing JSON.
-  /// final jwk = '{"kty": "RSA", "alg": "RS256", ...}';
+  /// Future<void> main() async {
+  ///   // JSON Web Key as a string containing JSON.
+  ///   final jwk = '{"kty": "RSA", "alg": "RS256", ...}';
   ///
-  /// // Import public key from decoded JSON.
-  /// final publicKey = await RsassaPkcs1V15PublicKey.importJsonWebKey(
-  ///   jsonDecode(jwk),
-  ///   Hash.sha256, // Must match the hash used the JWK key "alg"
-  /// );
+  ///   // Import public key from decoded JSON.
+  ///   final publicKey = await RsassaPkcs1V15PublicKey.importJsonWebKey(
+  ///     jsonDecode(jwk),
+  ///     Hash.sha256, // Must match the hash used the JWK key "alg"
+  ///   );
   ///
-  /// // Export the key (print it in same format as it was given).
-  /// Map<String, dynamic> keyData = await publicKey.exportJsonWebKey();
-  /// print(jsonEncode(keyData));
+  ///   // Export the key (print it in same format as it was given).
+  ///   Map<String, dynamic> keyData = await publicKey.exportJsonWebKey();
+  ///   print(jsonEncode(keyData));
+  /// }
   /// ```
   ///
   /// {@macro RSA-importJsonWebKey:use-key_ops}
@@ -517,24 +537,26 @@ final class RsassaPkcs1V15PublicKey {
   /// import 'dart:convert' show utf8;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Using privateKey Bob can sign a message for Alice.
-  /// final message = 'Hi Alice';
-  /// final signature = await keyPair.privateKey.signBytes(utf8.encode(message));
+  ///   // Using privateKey Bob can sign a message for Alice.
+  ///   final message = 'Hi Alice';
+  ///   final signature = await keyPair.privateKey.signBytes(utf8.encode(message));
   ///
-  /// // Given publicKey and signature Alice can verify the message from Bob.
-  /// final isValid = await keypair.publicKey.verifyBytes(
-  ///   signature,
-  ///   utf8.encode(message),
-  /// );
-  /// if (isValid) {
-  ///   print('Authentic message from Bob: $message');
+  ///   // Given publicKey and signature Alice can verify the message from Bob.
+  ///   final isValid = await keyPair.publicKey.verifyBytes(
+  ///     signature,
+  ///     utf8.encode(message),
+  ///   );
+  ///   if (isValid) {
+  ///     print('Authentic message from Bob: $message');
+  ///   }
   /// }
   /// ```
   Future<bool> verifyBytes(List<int> signature, List<int> data) =>
@@ -551,24 +573,26 @@ final class RsassaPkcs1V15PublicKey {
   /// import 'dart:convert' show utf8;
   /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Using privateKey Bob can sign a message for Alice.
-  /// final message = 'Hi Alice';
-  /// final signature = await keyPair.privateKey.signBytes(utf8.encode(message));
+  ///   // Using privateKey Bob can sign a message for Alice.
+  ///   final message = 'Hi Alice';
+  ///   final signature = await keyPair.privateKey.signBytes(utf8.encode(message));
   ///
-  /// // Given publicKey and signature Alice can verify the message from Bob.
-  /// final isValid = await keypair.publicKey.verifyStream(
-  ///   signature,
-  ///   Stream.fromIterable([utf8.encode(message)]),
-  /// );
-  /// if (isValid) {
-  ///   print('Authentic message from Bob: $message');
+  ///   // Given publicKey and signature Alice can verify the message from Bob.
+  ///   final isValid = await keyPair.publicKey.verifyStream(
+  ///     signature,
+  ///     Stream.fromIterable([utf8.encode(message)]),
+  ///   );
+  ///   if (isValid) {
+  ///     print('Authentic message from Bob: $message');
+  ///   }
   /// }
   /// ```
   Future<bool> verifyStream(List<int> signature, Stream<List<int>> data) =>
@@ -584,20 +608,22 @@ final class RsassaPkcs1V15PublicKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'package:pem/pem.dart';
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the public key.
-  /// final rawPublicKey = await keyPair.publicKey.exportSpkiKey();
+  ///   // Export the public key.
+  ///   final rawPublicKey = await keyPair.publicKey.exportSpkiKey();
   ///
-  /// // Public keys are often encoded as PEM.
-  /// // This encode the key in base64 and wraps it with:
-  /// // '-----BEGIN PUBLIC KEY-----'...
-  /// print(PemCodec(PemLabel.publicKey).encode(rawPublicKey));
+  ///   // Public keys are often encoded as PEM.
+  ///   // This encode the key in base64 and wraps it with:
+  ///   // '-----BEGIN PUBLIC KEY-----'...
+  ///   print(PemCodec(PemLabel.publicKey).encode(rawPublicKey));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc5280
@@ -612,20 +638,22 @@ final class RsassaPkcs1V15PublicKey {
   /// import 'package:webcrypto/webcrypto.dart';
   /// import 'dart:convert' show jsonEncode;
   ///
-  /// // Generate a key-pair.
-  /// final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
-  ///   4096,
-  ///   BigInt.from(65537),
-  ///   Hash.sha256,
-  /// );
+  /// Future<void> main() async {
+  ///   // Generate a key-pair.
+  ///   final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
+  ///     4096,
+  ///     BigInt.from(65537),
+  ///     Hash.sha256,
+  ///   );
   ///
-  /// // Export the public key.
-  /// final jwk = await keypair.publicKey.exportJsonWebKey();
+  ///   // Export the public key.
+  ///   final jwk = await keyPair.publicKey.exportJsonWebKey();
   ///
-  /// // The Map returned by `exportJsonWebKey()` can be converted to JSON with
-  /// // `jsonEncode` from `dart:convert`, this will print something like:
-  /// // {"kty": "RSA", "alg": "RS256", ...}
-  /// print(jsonEncode(jwk));
+  ///   // The Map returned by `exportJsonWebKey()` can be converted to JSON with
+  ///   // `jsonEncode` from `dart:convert`, this will print something like:
+  ///   // {"kty": "RSA", "alg": "RS256", ...}
+  ///   print(jsonEncode(jwk));
+  /// }
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc7517


### PR DESCRIPTION
Closes #101.

## Summary
- Wrap dartdoc examples that include imports in `main()` functions so they can be copied into runnable Dart files.
- Use `Future<void> main() async` for examples that await webcrypto APIs and `void main()` for the random-byte example.
- Fix a few `keypair`/wording typos in the touched examples while preserving the documented APIs.

## Validation
- `git diff --check`
- Custom script verified all dartdoc `dart` code blocks with imports now include a `main()` function.
