### PR TITLE
Add randomUUID() support

### DIFF
--- a/lib/src/crypto_subtle.dart
+++ b/lib/src/crypto_subtle.dart
@@ -71,6 +71,9 @@ extension type JSCrypto(JSObject _) implements JSObject {
 
   /// https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
   external JSTypedArray getRandomValues(JSTypedArray array);
+
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID
+  external String randomUUID();
 }
 
 const _webCryptoApiDocumentationUrl =
@@ -672,6 +675,10 @@ extension on JSJsonWebKey {
         .toList(),
     k: k,
   );
+}
+
+String randomUUID() {
+  return window.crypto.randomUUID();
 }
 
 // TODO: crypto.subtle.unwrapKey

--- a/lib/src/impl_ffi/impl_ffi.random.dart
+++ b/lib/src/impl_ffi/impl_ffi.random.dart
@@ -30,4 +30,23 @@ final class _RandomImpl implements RandomImpl {
       dest.setAll(0, out.asTypedList(dest.length));
     });
   }
+
+  @override
+  String randomUUID() {
+    return _Scope.sync((scope) {
+      final out = scope<ffi.Uint8>(16);
+      _checkOp(ssl.RAND_bytes(out, 16) == 1);
+      final bytes = out.asTypedList(16);
+      // Set UUID version to 4 (0100 in bits 12-15)
+      bytes[6] = (bytes[6] & 0x0F) | 0x40;
+      // Set variant to RFC 4122 (10 in bits 6-7)
+      bytes[8] = (bytes[8] & 0x3F) | 0x80;
+      final sb = StringBuffer();
+      for (var i = 0; i < 16; i++) {
+        if (i == 4 || i == 6 || i == 8 || i == 10) sb.write('-');
+        sb.write(bytes[i].toRadixString(16).padLeft(2, '0'));
+      }
+      return sb.toString();
+    });
+  }
 }

--- a/lib/src/impl_interface/impl_interface.random.dart
+++ b/lib/src/impl_interface/impl_interface.random.dart
@@ -16,4 +16,5 @@ part of 'impl_interface.dart';
 
 abstract interface class RandomImpl {
   void fillRandomBytes(TypedData destination);
+  String randomUUID();
 }

--- a/lib/src/impl_js/impl_js.random.dart
+++ b/lib/src/impl_js/impl_js.random.dart
@@ -32,4 +32,9 @@ final class _RandomImpl implements RandomImpl {
       throw _translateJavaScriptException();
     }
   }
+
+  @override
+  String randomUUID() {
+    return subtle.randomUUID();
+  }
 }

--- a/lib/src/impl_stub/impl_stub.random.dart
+++ b/lib/src/impl_stub/impl_stub.random.dart
@@ -21,4 +21,9 @@ final class _RandomImpl implements RandomImpl {
   void fillRandomBytes(TypedData destination) {
     throw UnimplementedError('Not implemented');
   }
+
+  @override
+  String randomUUID() {
+    throw UnimplementedError('Not implemented');
+  }
 }

--- a/lib/src/webcrypto/webcrypto.random.dart
+++ b/lib/src/webcrypto/webcrypto.random.dart
@@ -53,3 +53,26 @@ void fillRandomBytes(
 
   webCryptImpl.random.fillRandomBytes(destination);
 }
+
+/// Generate a random UUID v4 string.
+///
+/// Uses cryptographically secure random number generation to produce a
+/// version 4 UUID as specified in [RFC 4122][1].
+///
+/// Returns a string in the format `xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`
+/// where `x` is any hexadecimal digit and `y` is one of `8`, `9`, `a`, or `b`.
+///
+/// **Example**
+/// ```dart
+/// import 'package:webcrypto/webcrypto.dart';
+///
+/// void main() {
+///   final uuid = randomUUID();
+///   print(uuid); // e.g. "550e8400-e29b-41d4-a716-446655440000"
+/// }
+/// ```
+///
+/// [1]: https://datatracker.ietf.org/doc/html/rfc4122
+String randomUUID() {
+  return webCryptImpl.random.randomUUID();
+}

--- a/test/crypto_subtle_test.dart
+++ b/test/crypto_subtle_test.dart
@@ -104,6 +104,36 @@ void main() {
     });
   });
 
+  group('randomUUID', () {
+    test('returns a valid version 4 UUID', () {
+      final uuid = randomUUID();
+      expect(uuid, isA<String>());
+      // Format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+      expect(uuid.length, 36);
+      expect(uuid[14], '4');
+      expect('89ab'.contains(uuid[19]), isTrue);
+      final parts = uuid.split('-');
+      expect(parts.length, 5);
+      expect(parts[0].length, 8);
+      expect(parts[1].length, 4);
+      expect(parts[2].length, 4);
+      expect(parts[3].length, 4);
+      expect(parts[4].length, 12);
+      // All hex digits
+      for (final part in parts) {
+        expect(int.tryParse(part, radix: 16), isNotNull);
+      }
+    });
+
+    test('generates unique UUIDs', () {
+      final uuids = <String>{};
+      for (var i = 0; i < 100; i++) {
+        uuids.add(randomUUID());
+      }
+      expect(uuids.length, 100);
+    });
+  });
+
   group('crypto', () {
     test('subtle API is available in secure contexts', () {
       if (subtle.window.isSecureContext) {


### PR DESCRIPTION
Fixes #187

Adds \andomUUID()\ function matching the \Crypto.randomUUID()\ Web API:

- **JS backend**: delegates to \window.crypto.randomUUID()\ via \dart:js_interop\
- **FFI backend**: generates UUID v4 using BoringSSL \RAND_bytes\ with correct version (4) and variant (RFC 4122) bits
- **Stub backend**: throws \UnimplementedError\

The public API is a top-level \String randomUUID()\ function in \package:webcrypto\.

Tests verify:
- UUID format (length, dashes, version nibble, variant nibble, hex characters)
- Uniqueness across 100 generated UUIDs