### PR TITLE
WIP: docs: move HMAC importRawKey example to file

### DIFF
--- a/example/webcrypto/hmac/import_raw_key.dart
+++ b/example/webcrypto/hmac/import_raw_key.dart
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ignore_for_file: unused_local_variable
+
+// #region example
+import 'dart:convert' show base64;
+
+import 'package:webcrypto/webcrypto.dart';
+
+Future<void> main() async {
+  final key = await HmacSecretKey.importRawKey(
+    base64.decode(
+      'WzIxLDg0LDEwMCw5OSwxMCwxMDUsMjIsODAsMTkwLDExNiwyMDMsMjQ5XQ==',
+    ),
+    Hash.sha256,
+  );
+}
+
+// #endregion

--- a/lib/src/webcrypto/webcrypto.hmac.dart
+++ b/lib/src/webcrypto/webcrypto.hmac.dart
@@ -64,17 +64,8 @@ final class HmacSecretKey {
   /// as zero'ing the last bits in [keyData].
   ///
   /// **Example**
-  /// ```dart
-  /// import 'dart:convert' show utf8;
-  /// import 'package:webcrypto/webcrypto.dart';
   ///
-  /// Future<void> main() async {
-  ///   final key = await HmacSecretKey.importRawKey(
-  ///     base64.decode('WzIxLDg0LDEwMCw5OSwxMCwxMDUsMjIsODAsMTkwLDExNiwyMDMsMjQ5XQ=='),
-  ///     Hash.sha256,
-  ///   );
-  /// }
-  /// ```
+  /// {@example /example/webcrypto/hmac/import_raw_key.dart#example}
   static Future<HmacSecretKey> importRawKey(
     List<int> keyData,
     Hash hash, {


### PR DESCRIPTION
Addresses part of #283

## Summary

- Moves the `HmacSecretKey.importRawKey` dartdoc example into a standalone file under `example/webcrypto/hmac/import_raw_key.dart`.
- Replaces the inline dartdoc code block with a `{@example ...}` reference.
- Keeps this scoped to one HMAC example as an initial primitive-level cleanup.

## Notes

- Opened based on maintainer guidance in #283.
- This PR builds on #294, which ignores `doc_directive_unknown` until analyzer support for `{@example ...}` lands.
- This PR intentionally does not use `Fixes #283` because it only addresses part of the larger issue.

## Testing

- `dart format lib/src/webcrypto/webcrypto.hmac.dart example/webcrypto/hmac/import_raw_key.dart`
- `dart analyze`