### PR TITLE
chore: ignore unknown dartdoc example directive

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,3 +17,7 @@ analyzer:
   exclude:
     # Cannot analyze subprojects
     - example/webcrypto_demo_flutter_app/**
+  errors:
+    # TODO: Remove when analyzer supports the dartdoc `{@example ...}` directive.
+    # https://github.com/dart-lang/sdk/issues/63504
+    doc_directive_unknown: ignore


### PR DESCRIPTION
Addresses part of #283

## Summary
- Ignores `doc_directive_unknown` in `analysis_options.yaml`.
- Adds a comment linking to dart-lang/sdk#63504, which tracks analyzer support for the dartdoc `{@example ...}` directive.

## Notes
- This is a small follow-up PR based on maintainer guidance in #283.
- This should prevent future dartdoc example migration PRs from introducing analyzer warnings while analyzer support is still tracked upstream.

## Testing
- `dart analyze`