### PR TITLE
feat(impl_jni): add JCA backend skeleton and digest path

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -4,3 +4,10 @@ This application shows how to use `package:webcrypto` for computing a SHA-1
 hash of user provided string.
 
 Additionally, this example application provides integration tests for devices.
+
+To run the Android JNI/JCA digest smoke test:
+
+```sh
+flutter test integration_test/jni_digest_test.dart \
+  -d emulator-name
+```

--- a/example/integration_test/jni_digest_test.dart
+++ b/example/integration_test/jni_digest_test.dart
@@ -1,0 +1,22 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webcrypto/src/impl_jni/impl_jni.dart' as jni_impl;
+import 'package:webcrypto/webcrypto.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('JCA digest works through the public API', (_) async {
+    final data = utf8.encode('hello-world');
+    final digest = await Hash.sha256.digestBytes(data);
+    final jcaDigest = await jni_impl.webCryptImpl.sha256.digestBytes(data);
+
+    expect(digest, jcaDigest);
+    expect(
+      base64Encode(digest),
+      'r6J7RNQ7Aqn+pB0TztwuQBbPz4fF2/mQ5ZNmmqjOKG0=',
+    );
+  });
+}

--- a/example/integration_test/jni_digest_test.dart
+++ b/example/integration_test/jni_digest_test.dart
@@ -2,18 +2,15 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:webcrypto/src/impl_jni/impl_jni.dart' as jni_impl;
 import 'package:webcrypto/webcrypto.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('JCA digest works through the public API', (_) async {
+  testWidgets('public API SHA-256 digest matches known vector', (_) async {
     final data = utf8.encode('hello-world');
     final digest = await Hash.sha256.digestBytes(data);
-    final jcaDigest = await jni_impl.webCryptImpl.sha256.digestBytes(data);
 
-    expect(digest, jcaDigest);
     expect(
       base64Encode(digest),
       'r6J7RNQ7Aqn+pB0TztwuQBbPz4fF2/mQ5ZNmmqjOKG0=',

--- a/lib/src/impl_jni/impl_jni.aescbc.dart
+++ b/lib/src/impl_jni/impl_jni.aescbc.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:test/test.dart' show setUpAll, test;
-import 'package:webcrypto/src/testing/testing.dart';
+part of 'impl_jni.dart';
 
-import 'src/jni_test_setup.dart'
-    if (dart.library.io) 'src/jni_test_setup_io.dart';
+final class _StaticAesCbcSecretKeyImpl implements StaticAesCbcSecretKeyImpl {
+  const _StaticAesCbcSecretKeyImpl();
 
-void main() {
-  setUpAll(spawnJniForDesktopTests);
+  @override
+  Future<AesCbcSecretKeyImpl> importRawKey(List<int> keyData) =>
+      throw UnimplementedError('Not implemented');
 
-  runAllTests(test);
+  @override
+  Future<AesCbcSecretKeyImpl> importJsonWebKey(Map<String, dynamic> jwk) =>
+      throw UnimplementedError('Not implemented');
+
+  @override
+  Future<AesCbcSecretKeyImpl> generateKey(int length) =>
+      throw UnimplementedError('Not implemented');
 }

--- a/lib/src/impl_jni/impl_jni.aesctr.dart
+++ b/lib/src/impl_jni/impl_jni.aesctr.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:test/test.dart' show setUpAll, test;
-import 'package:webcrypto/src/testing/testing.dart';
+part of 'impl_jni.dart';
 
-import 'src/jni_test_setup.dart'
-    if (dart.library.io) 'src/jni_test_setup_io.dart';
+final class _StaticAesCtrSecretKeyImpl implements StaticAesCtrSecretKeyImpl {
+  const _StaticAesCtrSecretKeyImpl();
 
-void main() {
-  setUpAll(spawnJniForDesktopTests);
+  @override
+  Future<AesCtrSecretKeyImpl> importRawKey(List<int> keyData) =>
+      throw UnimplementedError('Not implemented');
 
-  runAllTests(test);
+  @override
+  Future<AesCtrSecretKeyImpl> importJsonWebKey(Map<String, dynamic> jwk) =>
+      throw UnimplementedError('Not implemented');
+
+  @override
+  Future<AesCtrSecretKeyImpl> generateKey(int length) =>
+      throw UnimplementedError('Not implemented');
 }

--- a/lib/src/impl_jni/impl_jni.aesgcm.dart
+++ b/lib/src/impl_jni/impl_jni.aesgcm.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:test/test.dart' show setUpAll, test;
-import 'package:webcrypto/src/testing/testing.dart';
+part of 'impl_jni.dart';
 
-import 'src/jni_test_setup.dart'
-    if (dart.library.io) 'src/jni_test_setup_io.dart';
+final class _StaticAesGcmSecretKeyImpl implements StaticAesGcmSecretKeyImpl {
+  const _StaticAesGcmSecretKeyImpl();
 
-void main() {
-  setUpAll(spawnJniForDesktopTests);
+  @override
+  Future<AesGcmSecretKeyImpl> importRawKey(List<int> keyData) =>
+      throw UnimplementedError('Not implemented');
 
-  runAllTests(test);
+  @override
+  Future<AesGcmSecretKeyImpl> importJsonWebKey(Map<String, dynamic> jwk) =>
+      throw UnimplementedError('Not implemented');
+
+  @override
+  Future<AesGcmSecretKeyImpl> generateKey(int length) =>
+      throw UnimplementedError('Not implemented');
 }

--- a/lib/src/impl_jni/impl_jni.dart
+++ b/lib/src/impl_jni/impl_jni.dart
@@ -1,0 +1,112 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Experimental JNI/JCA backend for the Android JCA exploration branch.
+///
+/// During exploration the Android JCA branch may temporarily wire native builds
+/// directly to this backend. The final FFI-vs-JNI selection mechanism can be
+/// settled once enough primitives exist to compare behavior across backends.
+library;
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:jni/jni.dart' as jni;
+import 'package:webcrypto/src/impl_interface/impl_interface.dart';
+
+import '../third_party/jca/generated_bindings.dart';
+
+part 'impl_jni.aescbc.dart';
+part 'impl_jni.aesctr.dart';
+part 'impl_jni.aesgcm.dart';
+part 'impl_jni.hmac.dart';
+part 'impl_jni.pbkdf2.dart';
+part 'impl_jni.ecdh.dart';
+part 'impl_jni.ecdsa.dart';
+part 'impl_jni.rsaoaep.dart';
+part 'impl_jni.hkdf.dart';
+part 'impl_jni.rsapss.dart';
+part 'impl_jni.rsassapkcs1v15.dart';
+part 'impl_jni.digest.dart';
+part 'impl_jni.random.dart';
+part 'impl_jni.utils.dart';
+
+const WebCryptoImpl webCryptImpl = _WebCryptoImpl();
+
+final class _WebCryptoImpl implements WebCryptoImpl {
+  const _WebCryptoImpl();
+
+  @override
+  final aesCbcSecretKey = const _StaticAesCbcSecretKeyImpl();
+
+  @override
+  final aesCtrSecretKey = const _StaticAesCtrSecretKeyImpl();
+
+  @override
+  final aesGcmSecretKey = const _StaticAesGcmSecretKeyImpl();
+
+  @override
+  final hmacSecretKey = const _StaticHmacSecretKeyImpl();
+
+  @override
+  final pbkdf2SecretKey = const _StaticPbkdf2SecretKeyImpl();
+
+  @override
+  final ecdhPrivateKey = const _StaticEcdhPrivateKeyImpl();
+
+  @override
+  final ecdhPublicKey = const _StaticEcdhPublicKeyImpl();
+
+  @override
+  final ecdsaPrivateKey = const _StaticEcdsaPrivateKeyImpl();
+
+  @override
+  final ecdsaPublicKey = const _StaticEcdsaPublicKeyImpl();
+
+  @override
+  final rsaOaepPrivateKey = const _StaticRsaOaepPrivateKeyImpl();
+
+  @override
+  final rsaOaepPublicKey = const _StaticRsaOaepPublicKeyImpl();
+
+  @override
+  final hkdfSecretKey = const _StaticHkdfSecretKeyImpl();
+
+  @override
+  final rsaPssPrivateKey = const _StaticRsaPssPrivateKeyImpl();
+
+  @override
+  final rsaPssPublicKey = const _StaticRsaPssPublicKeyImpl();
+
+  @override
+  final rsaSsaPkcs1v15PrivateKey = const _StaticRsaSsaPkcs1V15PrivateKeyImpl();
+
+  @override
+  final rsaSsaPkcs1v15PublicKey = const _StaticRsaSsaPkcs1V15PublicKeyImpl();
+
+  @override
+  final sha1 = const _HashImpl('SHA-1');
+
+  @override
+  final sha256 = const _HashImpl('SHA-256');
+
+  @override
+  final sha384 = const _HashImpl('SHA-384');
+
+  @override
+  final sha512 = const _HashImpl('SHA-512');
+
+  @override
+  final random = const _RandomImpl();
+}

--- a/lib/src/impl_jni/impl_jni.digest.dart
+++ b/lib/src/impl_jni/impl_jni.digest.dart
@@ -42,13 +42,14 @@ final class _HashImpl implements HashImpl {
 
   @override
   Future<Uint8List> digestStream(Stream<List<int>> data) async {
-    final algorithm = jni.JString.fromString(_jcaName);
-    final digest = MessageDigest.getInstance(algorithm);
-    algorithm.release();
-
-    if (digest == null) {
-      throw operationError('JCA MessageDigest($_jcaName) is unavailable');
-    }
+    final digest = jni.using((arena) {
+      final algorithm = jni.JString.fromString(_jcaName)..releasedBy(arena);
+      final digest = MessageDigest.getInstance(algorithm);
+      if (digest == null) {
+        throw operationError('JCA MessageDigest($_jcaName) is unavailable');
+      }
+      return digest;
+    });
 
     try {
       await for (final chunk in data) {

--- a/lib/src/impl_jni/impl_jni.digest.dart
+++ b/lib/src/impl_jni/impl_jni.digest.dart
@@ -1,0 +1,74 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of 'impl_jni.dart';
+
+final class _HashImpl implements HashImpl {
+  const _HashImpl(this._jcaName);
+
+  final String _jcaName;
+
+  @override
+  Future<Uint8List> digestBytes(List<int> data) async {
+    return jni.using((arena) {
+      final algorithm = jni.JString.fromString(_jcaName)..releasedBy(arena);
+      final digest = MessageDigest.getInstance(algorithm);
+      if (digest == null) {
+        throw operationError('JCA MessageDigest($_jcaName) is unavailable');
+      }
+      digest.releasedBy(arena);
+
+      final input = jni.JByteArray.from(data)..releasedBy(arena);
+      final result = digest.digest$2(input);
+      if (result == null) {
+        throw operationError('JCA MessageDigest($_jcaName) returned null');
+      }
+      result.releasedBy(arena);
+
+      return result.copyToDartBytes();
+    });
+  }
+
+  @override
+  Future<Uint8List> digestStream(Stream<List<int>> data) async {
+    final algorithm = jni.JString.fromString(_jcaName);
+    final digest = MessageDigest.getInstance(algorithm);
+    algorithm.release();
+
+    if (digest == null) {
+      throw operationError('JCA MessageDigest($_jcaName) is unavailable');
+    }
+
+    try {
+      await for (final chunk in data) {
+        jni.using((arena) {
+          final input = jni.JByteArray.from(chunk)..releasedBy(arena);
+          digest.update$2(input);
+        });
+      }
+
+      final result = digest.digest();
+      if (result == null) {
+        throw operationError('JCA MessageDigest($_jcaName) returned null');
+      }
+      try {
+        return result.copyToDartBytes();
+      } finally {
+        result.release();
+      }
+    } finally {
+      digest.release();
+    }
+  }
+}

--- a/lib/src/impl_jni/impl_jni.ecdh.dart
+++ b/lib/src/impl_jni/impl_jni.ecdh.dart
@@ -1,0 +1,58 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of 'impl_jni.dart';
+
+final class _StaticEcdhPrivateKeyImpl implements StaticEcdhPrivateKeyImpl {
+  const _StaticEcdhPrivateKeyImpl();
+
+  @override
+  Future<EcdhPrivateKeyImpl> importPkcs8Key(
+    List<int> keyData,
+    EllipticCurve curve,
+  ) => throw UnimplementedError('Not implemented');
+
+  @override
+  Future<EcdhPrivateKeyImpl> importJsonWebKey(
+    Map<String, dynamic> jwk,
+    EllipticCurve curve,
+  ) => throw UnimplementedError('Not implemented');
+
+  @override
+  Future<(EcdhPrivateKeyImpl, EcdhPublicKeyImpl)> generateKey(
+    EllipticCurve curve,
+  ) => throw UnimplementedError('Not implemented');
+}
+
+final class _StaticEcdhPublicKeyImpl implements StaticEcdhPublicKeyImpl {
+  const _StaticEcdhPublicKeyImpl();
+
+  @override
+  Future<EcdhPublicKeyImpl> importRawKey(
+    List<int> keyData,
+    EllipticCurve curve,
+  ) => throw UnimplementedError('Not implemented');
+
+  @override
+  Future<EcdhPublicKeyImpl> importSpkiKey(
+    List<int> keyData,
+    EllipticCurve curve,
+  ) => throw UnimplementedError('Not implemented');
+
+  @override
+  Future<EcdhPublicKeyImpl> importJsonWebKey(
+    Map<String, dynamic> jwk,
+    EllipticCurve curve,
+  ) => throw UnimplementedError('Not implemented');
+}

--- a/lib/src/impl_jni/impl_jni.ecdsa.dart
+++ b/lib/src/impl_jni/impl_jni.ecdsa.dart
@@ -1,0 +1,58 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of 'impl_jni.dart';
+
+final class _StaticEcdsaPrivateKeyImpl implements StaticEcdsaPrivateKeyImpl {
+  const _StaticEcdsaPrivateKeyImpl();
+
+  @override
+  Future<EcdsaPrivateKeyImpl> importPkcs8Key(
+    List<int> keyData,
+    EllipticCurve curve,
+  ) => throw UnimplementedError('Not implemented');
+
+  @override
+  Future<EcdsaPrivateKeyImpl> importJsonWebKey(
+    Map<String, dynamic> jwk,
+    EllipticCurve curve,
+  ) => throw UnimplementedError('Not implemented');
+
+  @override
+  Future<(EcdsaPrivateKeyImpl, EcdsaPublicKeyImpl)> generateKey(
+    EllipticCurve curve,
+  ) => throw UnimplementedError('Not implemented');
+}
+
+final class _StaticEcdsaPublicKeyImpl implements StaticEcdsaPublicKeyImpl {
+  const _StaticEcdsaPublicKeyImpl();
+
+  @override
+  Future<EcdsaPublicKeyImpl> importRawKey(
+    List<int> keyData,
+    EllipticCurve curve,
+  ) => throw UnimplementedError('Not implemented');
+
+  @override
+  Future<EcdsaPublicKeyImpl> importJsonWebKey(
+    Map<String, dynamic> jwk,
+    EllipticCurve curve,
+  ) => throw UnimplementedError('Not implemented');
+
+  @override
+  Future<EcdsaPublicKeyImpl> importSpkiKey(
+    List<int> keyData,
+    EllipticCurve curve,
+  ) => throw UnimplementedError('Not implemented');
+}

--- a/lib/src/impl_jni/impl_jni.hkdf.dart
+++ b/lib/src/impl_jni/impl_jni.hkdf.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:test/test.dart' show setUpAll, test;
-import 'package:webcrypto/src/testing/testing.dart';
+part of 'impl_jni.dart';
 
-import 'src/jni_test_setup.dart'
-    if (dart.library.io) 'src/jni_test_setup_io.dart';
+final class _StaticHkdfSecretKeyImpl implements StaticHkdfSecretKeyImpl {
+  const _StaticHkdfSecretKeyImpl();
 
-void main() {
-  setUpAll(spawnJniForDesktopTests);
-
-  runAllTests(test);
+  @override
+  Future<HkdfSecretKeyImpl> importRawKey(List<int> keyData) =>
+      throw UnimplementedError('Not implemented');
 }

--- a/lib/src/impl_jni/impl_jni.hmac.dart
+++ b/lib/src/impl_jni/impl_jni.hmac.dart
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of 'impl_jni.dart';
+
+final class _StaticHmacSecretKeyImpl implements StaticHmacSecretKeyImpl {
+  const _StaticHmacSecretKeyImpl();
+
+  @override
+  Future<HmacSecretKeyImpl> importRawKey(
+    List<int> keyData,
+    HashImpl hash, {
+    int? length,
+  }) {
+    throw UnimplementedError('Not implemented');
+  }
+
+  @override
+  Future<HmacSecretKeyImpl> importJsonWebKey(
+    Map<String, dynamic> jwk,
+    HashImpl hash, {
+    int? length,
+  }) {
+    throw UnimplementedError('Not implemented');
+  }
+
+  @override
+  Future<HmacSecretKeyImpl> generateKey(HashImpl hash, {int? length = 32}) {
+    throw UnimplementedError('Not implemented');
+  }
+}

--- a/lib/src/impl_jni/impl_jni.pbkdf2.dart
+++ b/lib/src/impl_jni/impl_jni.pbkdf2.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:test/test.dart' show setUpAll, test;
-import 'package:webcrypto/src/testing/testing.dart';
+part of 'impl_jni.dart';
 
-import 'src/jni_test_setup.dart'
-    if (dart.library.io) 'src/jni_test_setup_io.dart';
+final class _StaticPbkdf2SecretKeyImpl implements StaticPbkdf2SecretKeyImpl {
+  const _StaticPbkdf2SecretKeyImpl();
 
-void main() {
-  setUpAll(spawnJniForDesktopTests);
-
-  runAllTests(test);
+  @override
+  Future<Pbkdf2SecretKeyImpl> importRawKey(List<int> keyData) {
+    throw UnimplementedError('Not implemented');
+  }
 }

--- a/lib/src/impl_jni/impl_jni.random.dart
+++ b/lib/src/impl_jni/impl_jni.random.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:test/test.dart' show setUpAll, test;
-import 'package:webcrypto/src/testing/testing.dart';
+part of 'impl_jni.dart';
 
-import 'src/jni_test_setup.dart'
-    if (dart.library.io) 'src/jni_test_setup_io.dart';
+final class _RandomImpl implements RandomImpl {
+  const _RandomImpl();
 
-void main() {
-  setUpAll(spawnJniForDesktopTests);
-
-  runAllTests(test);
+  @override
+  void fillRandomBytes(TypedData destination) {
+    throw UnimplementedError('Not implemented');
+  }
 }

--- a/lib/src/impl_jni/impl_jni.rsaoaep.dart
+++ b/lib/src/impl_jni/impl_jni.rsaoaep.dart
@@ -1,0 +1,62 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of 'impl_jni.dart';
+
+final class _StaticRsaOaepPrivateKeyImpl
+    implements StaticRsaOaepPrivateKeyImpl {
+  const _StaticRsaOaepPrivateKeyImpl();
+
+  @override
+  Future<RsaOaepPrivateKeyImpl> importPkcs8Key(
+    List<int> keyData,
+    HashImpl hash,
+  ) {
+    throw UnimplementedError('Not implemented');
+  }
+
+  @override
+  Future<RsaOaepPrivateKeyImpl> importJsonWebKey(
+    Map<String, dynamic> jwk,
+    HashImpl hash,
+  ) {
+    throw UnimplementedError('Not implemented');
+  }
+
+  @override
+  Future<(RsaOaepPrivateKeyImpl, RsaOaepPublicKeyImpl)> generateKey(
+    int modulusLength,
+    BigInt publicExponent,
+    HashImpl hash,
+  ) {
+    throw UnimplementedError('Not implemented');
+  }
+}
+
+final class _StaticRsaOaepPublicKeyImpl implements StaticRsaOaepPublicKeyImpl {
+  const _StaticRsaOaepPublicKeyImpl();
+
+  @override
+  Future<RsaOaepPublicKeyImpl> importSpkiKey(List<int> keyData, HashImpl hash) {
+    throw UnimplementedError('Not implemented');
+  }
+
+  @override
+  Future<RsaOaepPublicKeyImpl> importJsonWebKey(
+    Map<String, dynamic> jwk,
+    HashImpl hash,
+  ) {
+    throw UnimplementedError('Not implemented');
+  }
+}

--- a/lib/src/impl_jni/impl_jni.rsapss.dart
+++ b/lib/src/impl_jni/impl_jni.rsapss.dart
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of 'impl_jni.dart';
+
+final class _StaticRsaPssPrivateKeyImpl implements StaticRsaPssPrivateKeyImpl {
+  const _StaticRsaPssPrivateKeyImpl();
+
+  @override
+  Future<RsaPssPrivateKeyImpl> importPkcs8Key(
+    List<int> keyData,
+    HashImpl hash,
+  ) => throw UnimplementedError('Not implemented');
+
+  @override
+  Future<RsaPssPrivateKeyImpl> importJsonWebKey(
+    Map<String, dynamic> jwk,
+    HashImpl hash,
+  ) => throw UnimplementedError('Not implemented');
+
+  @override
+  Future<(RsaPssPrivateKeyImpl, RsaPssPublicKeyImpl)> generateKey(
+    int modulusLength,
+    BigInt publicExponent,
+    HashImpl hash,
+  ) => throw UnimplementedError('Not implemented');
+}
+
+final class _StaticRsaPssPublicKeyImpl implements StaticRsaPssPublicKeyImpl {
+  const _StaticRsaPssPublicKeyImpl();
+
+  @override
+  Future<RsaPssPublicKeyImpl> importSpkiKey(List<int> keyData, HashImpl hash) =>
+      throw UnimplementedError('Not implemented');
+
+  @override
+  Future<RsaPssPublicKeyImpl> importJsonWebKey(
+    Map<String, dynamic> jwk,
+    HashImpl hash,
+  ) => throw UnimplementedError('Not implemented');
+}

--- a/lib/src/impl_jni/impl_jni.rsassapkcs1v15.dart
+++ b/lib/src/impl_jni/impl_jni.rsassapkcs1v15.dart
@@ -1,0 +1,54 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of 'impl_jni.dart';
+
+final class _StaticRsaSsaPkcs1V15PrivateKeyImpl
+    implements StaticRsaSsaPkcs1v15PrivateKeyImpl {
+  const _StaticRsaSsaPkcs1V15PrivateKeyImpl();
+
+  @override
+  Future<RsaSsaPkcs1V15PrivateKeyImpl> importPkcs8Key(
+    List<int> keyData,
+    HashImpl hash,
+  ) => throw UnimplementedError('Not implemented');
+
+  @override
+  Future<RsaSsaPkcs1V15PrivateKeyImpl> importJsonWebKey(
+    Map<String, dynamic> jwk,
+    HashImpl hash,
+  ) => throw UnimplementedError('Not implemented');
+
+  @override
+  Future<(RsaSsaPkcs1V15PrivateKeyImpl, RsaSsaPkcs1V15PublicKeyImpl)>
+  generateKey(int modulusLength, BigInt publicExponent, HashImpl hash) =>
+      throw UnimplementedError('Not implemented');
+}
+
+final class _StaticRsaSsaPkcs1V15PublicKeyImpl
+    implements StaticRsaSsaPkcs1v15PublicKeyImpl {
+  const _StaticRsaSsaPkcs1V15PublicKeyImpl();
+
+  @override
+  Future<RsaSsaPkcs1V15PublicKeyImpl> importSpkiKey(
+    List<int> keyData,
+    HashImpl hash,
+  ) => throw UnimplementedError('Not implemented');
+
+  @override
+  Future<RsaSsaPkcs1V15PublicKeyImpl> importJsonWebKey(
+    Map<String, dynamic> jwk,
+    HashImpl hash,
+  ) => throw UnimplementedError('Not implemented');
+}

--- a/lib/src/impl_jni/impl_jni.utils.dart
+++ b/lib/src/impl_jni/impl_jni.utils.dart
@@ -1,0 +1,28 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of 'impl_jni.dart';
+
+extension _JByteArrayCopy on jni.JByteArray {
+  /// Copies this JVM byte array into Dart-owned memory.
+  ///
+  /// `getRange` returns a typed list backed by a native buffer whose lifetime
+  /// is finalizer-driven. Copy once more before releasing the Java array so
+  /// webcrypto callers receive a normal Dart-managed [Uint8List].
+  Uint8List copyToDartBytes() {
+    final bytes = getRange(0, length);
+    final view = bytes.buffer.asUint8List(bytes.offsetInBytes, bytes.length);
+    return Uint8List.fromList(view);
+  }
+}

--- a/lib/src/webcrypto/webcrypto.dart
+++ b/lib/src/webcrypto/webcrypto.dart
@@ -24,8 +24,10 @@ import 'dart:convert';
 import 'dart:async';
 import 'dart:typed_data';
 import '../impl_interface/impl_interface.dart';
+// TODO: Replace this temporary android-jca exploration wiring with the final
+// native backend selector once the JNI/JCA backend shape is clearer.
 import '../impl_stub/impl_stub.dart'
-    if (dart.library.ffi) '../impl_ffi/impl_ffi.dart'
+    if (dart.library.ffi) '../impl_jni/impl_jni.dart'
     if (dart.library.js_interop) '../impl_js/impl_js.dart'
     show webCryptImpl;
 

--- a/test/impl_jni_digest_test.dart
+++ b/test/impl_jni_digest_test.dart
@@ -16,31 +16,23 @@
 library;
 
 import 'dart:convert';
-import 'dart:io';
 
-import 'package:jni/jni.dart';
 import 'package:test/test.dart';
 import 'package:webcrypto/src/impl_ffi/impl_ffi.dart' as ffi_impl;
 import 'package:webcrypto/src/impl_jni/impl_jni.dart' as jni_impl;
 
+import 'src/jni_test_setup.dart'
+    if (dart.library.io) 'src/jni_test_setup_io.dart';
+
 void main() {
+  final skipReason = jniHelperSetupSkipReason;
+
   setUpAll(() {
-    if (Platform.isAndroid) {
+    if (skipReason != null) {
       return;
     }
 
-    final helperDir = Directory('build/jni_libs');
-    final helperName = Platform.isWindows
-        ? 'dartjni.dll'
-        : Platform.isMacOS
-        ? 'libdartjni.dylib'
-        : 'libdartjni.so';
-    if (!File.fromUri(helperDir.uri.resolve(helperName)).existsSync()) {
-      markTestSkipped('Run `dart run jni:setup` before desktop JNI tests.');
-      return;
-    }
-
-    Jni.spawnIfNotExists(dylibDir: helperDir.path);
+    spawnJniForDesktopTests();
   });
 
   test('JCA digest matches known SHA-256 vector', () async {
@@ -53,7 +45,7 @@ void main() {
       base64Encode(digest),
       'r6J7RNQ7Aqn+pB0TztwuQBbPz4fF2/mQ5ZNmmqjOKG0=',
     );
-  });
+  }, skip: skipReason);
 
   test('JCA digest stream matches known SHA-512 vector', () async {
     final data = utf8.encode('hello-world');
@@ -70,5 +62,5 @@ void main() {
       'au78KRIqOWLJDvg09sqtADO//NYpQbemIFppXMOeJ2fbd3inrXbRc6CDueFLIQ3AISkj'
       '9IGyhceEqx/jQNf/TQ==',
     );
-  });
+  }, skip: skipReason);
 }

--- a/test/impl_jni_digest_test.dart
+++ b/test/impl_jni_digest_test.dart
@@ -1,0 +1,74 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:jni/jni.dart';
+import 'package:test/test.dart';
+import 'package:webcrypto/src/impl_ffi/impl_ffi.dart' as ffi_impl;
+import 'package:webcrypto/src/impl_jni/impl_jni.dart' as jni_impl;
+
+void main() {
+  setUpAll(() {
+    if (Platform.isAndroid) {
+      return;
+    }
+
+    final helperDir = Directory('build/jni_libs');
+    final helperName = Platform.isWindows
+        ? 'dartjni.dll'
+        : Platform.isMacOS
+        ? 'libdartjni.dylib'
+        : 'libdartjni.so';
+    if (!File.fromUri(helperDir.uri.resolve(helperName)).existsSync()) {
+      markTestSkipped('Run `dart run jni:setup` before desktop JNI tests.');
+      return;
+    }
+
+    Jni.spawnIfNotExists(dylibDir: helperDir.path);
+  });
+
+  test('JCA digest matches known SHA-256 vector', () async {
+    final data = utf8.encode('hello-world');
+    final digest = await jni_impl.webCryptImpl.sha256.digestBytes(data);
+    final ffiDigest = await ffi_impl.webCryptImpl.sha256.digestBytes(data);
+
+    expect(digest, ffiDigest);
+    expect(
+      base64Encode(digest),
+      'r6J7RNQ7Aqn+pB0TztwuQBbPz4fF2/mQ5ZNmmqjOKG0=',
+    );
+  });
+
+  test('JCA digest stream matches known SHA-512 vector', () async {
+    final data = utf8.encode('hello-world');
+    final digest = await jni_impl.webCryptImpl.sha512.digestStream(
+      Stream.value(data),
+    );
+    final ffiDigest = await ffi_impl.webCryptImpl.sha512.digestStream(
+      Stream.value(data),
+    );
+
+    expect(digest, ffiDigest);
+    expect(
+      base64Encode(digest),
+      'au78KRIqOWLJDvg09sqtADO//NYpQbemIFppXMOeJ2fbd3inrXbRc6CDueFLIQ3AISkj'
+      '9IGyhceEqx/jQNf/TQ==',
+    );
+  });
+}

--- a/test/src/jni_test_setup.dart
+++ b/test/src/jni_test_setup.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:test/test.dart' show setUpAll, test;
-import 'package:webcrypto/src/testing/testing.dart';
-
-import 'src/jni_test_setup.dart'
-    if (dart.library.io) 'src/jni_test_setup_io.dart';
-
-void main() {
-  setUpAll(spawnJniForDesktopTests);
-
-  runAllTests(test);
-}
+void spawnJniForDesktopTests() {}

--- a/test/src/jni_test_setup.dart
+++ b/test/src/jni_test_setup.dart
@@ -12,4 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const String? jniHelperSetupSkipReason = null;
+
 void spawnJniForDesktopTests() {}

--- a/test/src/jni_test_setup_io.dart
+++ b/test/src/jni_test_setup_io.dart
@@ -1,0 +1,37 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:jni/jni.dart';
+
+void spawnJniForDesktopTests() {
+  if (Platform.isAndroid) {
+    return;
+  }
+
+  final helperDir = Directory('build/jni_libs');
+  final helperName = Platform.isWindows
+      ? 'dartjni.dll'
+      : Platform.isMacOS
+      ? 'libdartjni.dylib'
+      : 'libdartjni.so';
+  // Keep regular non-JNI test runs usable; `dart run jni:setup` opts desktop
+  // tests into the JNI helper needed by the android-jca exploration backend.
+  if (!File.fromUri(helperDir.uri.resolve(helperName)).existsSync()) {
+    return;
+  }
+
+  Jni.spawnIfNotExists(dylibDir: helperDir.path);
+}

--- a/test/src/jni_test_setup_io.dart
+++ b/test/src/jni_test_setup_io.dart
@@ -16,22 +16,37 @@ import 'dart:io';
 
 import 'package:jni/jni.dart';
 
+const _desktopJniSetupMessage =
+    'Run `dart run jni:setup` before running desktop JNI tests.';
+
+String? get jniHelperSetupSkipReason {
+  if (Platform.isAndroid) {
+    return null;
+  }
+
+  return _desktopJniHelperFile.existsSync() ? null : _desktopJniSetupMessage;
+}
+
 void spawnJniForDesktopTests() {
+  final setupError = jniHelperSetupSkipReason;
+  if (setupError != null) {
+    throw StateError(setupError);
+  }
+
   if (Platform.isAndroid) {
     return;
   }
 
-  final helperDir = Directory('build/jni_libs');
+  Jni.spawnIfNotExists(dylibDir: _desktopJniHelperDir.path);
+}
+
+Directory get _desktopJniHelperDir => Directory('build/jni_libs');
+
+File get _desktopJniHelperFile {
   final helperName = Platform.isWindows
       ? 'dartjni.dll'
       : Platform.isMacOS
       ? 'libdartjni.dylib'
       : 'libdartjni.so';
-  // Keep regular non-JNI test runs usable; `dart run jni:setup` opts desktop
-  // tests into the JNI helper needed by the android-jca exploration backend.
-  if (!File.fromUri(helperDir.uri.resolve(helperName)).existsSync()) {
-    return;
-  }
-
-  Jni.spawnIfNotExists(dylibDir: helperDir.path);
+  return File.fromUri(_desktopJniHelperDir.uri.resolve(helperName));
 }


### PR DESCRIPTION
## Summary

This PR adds the first Android JCA exploration slice on top of `android-jca-branch`.

It includes:
- an experimental `lib/src/impl_jni` backend skeleton following `WebCryptoImpl`
- JCA `MessageDigest` support for SHA-1, SHA-256, SHA-384, and SHA-512
- scoped JNI object release for transient Java objects
- a `JByteArray.copyToDartBytes()` helper so digest output is copied into Dart-owned memory
- temporary native import wiring to use the JNI backend on this exploration branch
- focused desktop JNI digest tests
- an Android example integration smoke test proving the public API uses the JNI digest path

Generated JNI bindings are intentionally not part of this PR. They were split out and landed separately in #297.

Non-digest primitives are still stubbed. This is intentional for the first slice so the branch establishes backend shape, digest behavior, and testing flow before adding HMAC/AES-GCM/etc.

## Testing

```sh
dart analyze
dart run jni:setup
dart test test/impl_jni_digest_test.dart
```

Android, inside example app directory:
```sh
flutter test integration_test/jni_digest_test.dart -d emulator-name
```

