### PR TITLE
Fix HMAC JWK import length handling

### DIFF
--- a/lib/src/impl_ffi/impl_ffi.hmac.dart
+++ b/lib/src/impl_ffi/impl_ffi.hmac.dart
@@ -43,6 +43,24 @@ Future<HmacSecretKeyImpl> hmacSecretKey_importRawKey(
   );
 }
 
+void _checkHmacJwkLength(List<int> keyData, int length) {
+  _checkData(
+    length >= 0 &&
+        length <= keyData.length * 8 &&
+        length > (keyData.length - 1) * 8,
+    message: 'JWK property "k" does not match expected length',
+  );
+
+  final remainder = length % 8;
+  if (remainder != 0) {
+    final unusedBitsMask = 0xff >> remainder;
+    _checkData(
+      keyData.last & unusedBitsMask == 0,
+      message: 'JWK property "k" has non-zero unused bits',
+    );
+  }
+}
+
 Future<HmacSecretKeyImpl> hmacSecretKey_importJsonWebKey(
   Map<String, dynamic> jwk,
   HashImpl hash, {
@@ -65,8 +83,11 @@ Future<HmacSecretKeyImpl> hmacSecretKey_importJsonWebKey(
   );
 
   final keyData = _jwkDecodeBase64UrlNoPadding(k.k!, 'k');
+  if (length != null) {
+    _checkHmacJwkLength(keyData, length);
+  }
 
-  return hmacSecretKey_importRawKey(keyData, hash, length: length);
+  return _HmacSecretKeyImpl(keyData, h);
 }
 
 Future<HmacSecretKeyImpl> hmacSecretKey_generateKey(

--- a/lib/src/impl_ffi/impl_ffi.hmac.dart
+++ b/lib/src/impl_ffi/impl_ffi.hmac.dart
@@ -43,22 +43,13 @@ Future<HmacSecretKeyImpl> hmacSecretKey_importRawKey(
   );
 }
 
-void _checkHmacJwkLength(List<int> keyData, int length) {
+void _checkHmacLength(List<int> keyData, int length) {
   _checkData(
     length >= 0 &&
         length <= keyData.length * 8 &&
         length > (keyData.length - 1) * 8,
     message: 'JWK property "k" does not match expected length',
   );
-
-  final remainder = length % 8;
-  if (remainder != 0) {
-    final unusedBitsMask = 0xff >> remainder;
-    _checkData(
-      keyData.last & unusedBitsMask == 0,
-      message: 'JWK property "k" has non-zero unused bits',
-    );
-  }
 }
 
 Future<HmacSecretKeyImpl> hmacSecretKey_importJsonWebKey(
@@ -84,10 +75,10 @@ Future<HmacSecretKeyImpl> hmacSecretKey_importJsonWebKey(
 
   final keyData = _jwkDecodeBase64UrlNoPadding(k.k!, 'k');
   if (length != null) {
-    _checkHmacJwkLength(keyData, length);
+    _checkHmacLength(keyData, length);
   }
 
-  return _HmacSecretKeyImpl(keyData, h);
+  return hmacSecretKey_importRawKey(keyData, hash, length: length);
 }
 
 Future<HmacSecretKeyImpl> hmacSecretKey_generateKey(

--- a/lib/src/impl_js/impl_js.dart
+++ b/lib/src/impl_js/impl_js.dart
@@ -15,6 +15,7 @@
 library impl_js;
 
 import 'dart:async';
+import 'dart:convert' show base64Url;
 import 'dart:typed_data';
 
 import 'package:webcrypto/src/impl_interface/impl_interface.dart';

--- a/lib/src/impl_js/impl_js.dart
+++ b/lib/src/impl_js/impl_js.dart
@@ -15,7 +15,6 @@
 library;
 
 import 'dart:async';
-import 'dart:convert' show base64Url;
 import 'dart:js_interop';
 import 'dart:typed_data';
 

--- a/lib/src/impl_js/impl_js.hmac.dart
+++ b/lib/src/impl_js/impl_js.hmac.dart
@@ -40,55 +40,21 @@ Future<HmacSecretKeyImpl> hmacSecretKey_importRawKey(
   );
 }
 
-Uint8List _jwkDecodeBase64UrlNoPadding(String unpadded, String prop) {
-  try {
-    final padded = unpadded.padRight(
-      unpadded.length + ((4 - (unpadded.length % 4)) % 4),
-      '=',
-    );
-    return base64Url.decode(padded);
-  } on FormatException {
-    throw FormatException(
-      'JWK property "$prop" is not url-safe base64 without padding',
-      unpadded,
-    );
-  }
-}
-
-void _checkHmacJwkLength(List<int> keyData, int length) {
-  if (length < 0 ||
-      length > keyData.length * 8 ||
-      length <= (keyData.length - 1) * 8) {
-    throw const FormatException(
-      'JWK property "k" does not match expected length',
-    );
-  }
-
-  final remainder = length % 8;
-  if (remainder != 0) {
-    final unusedBitsMask = 0xff >> remainder;
-    if (keyData.last & unusedBitsMask != 0) {
-      throw const FormatException('JWK property "k" has non-zero unused bits');
-    }
-  }
-}
-
 Future<HmacSecretKeyImpl> hmacSecretKey_importJsonWebKey(
   Map<String, dynamic> jwk,
   HashImpl hash, {
   int? length,
 }) async {
-  if (length != null && jwk['k'] is String) {
-    _checkHmacJwkLength(
-      _jwkDecodeBase64UrlNoPadding(jwk['k'] as String, 'k'),
-      length,
-    );
-  }
-
   return _HmacSecretKeyImpl(
     await _importJsonWebKey(
       jwk,
-      subtle.Algorithm(name: 'HMAC', hash: _getHashAlgorithm(hash)),
+      length == null
+          ? subtle.Algorithm(name: 'HMAC', hash: _getHashAlgorithm(hash))
+          : subtle.Algorithm(
+              name: 'HMAC',
+              hash: _getHashAlgorithm(hash),
+              length: length,
+            ),
       _usagesSignVerify,
       'secret',
     ),

--- a/lib/src/impl_js/impl_js.hmac.dart
+++ b/lib/src/impl_js/impl_js.hmac.dart
@@ -40,21 +40,55 @@ Future<HmacSecretKeyImpl> hmacSecretKey_importRawKey(
   );
 }
 
+Uint8List _jwkDecodeBase64UrlNoPadding(String unpadded, String prop) {
+  try {
+    final padded = unpadded.padRight(
+      unpadded.length + ((4 - (unpadded.length % 4)) % 4),
+      '=',
+    );
+    return base64Url.decode(padded);
+  } on FormatException {
+    throw FormatException(
+      'JWK property "$prop" is not url-safe base64 without padding',
+      unpadded,
+    );
+  }
+}
+
+void _checkHmacJwkLength(List<int> keyData, int length) {
+  if (length < 0 ||
+      length > keyData.length * 8 ||
+      length <= (keyData.length - 1) * 8) {
+    throw const FormatException(
+      'JWK property "k" does not match expected length',
+    );
+  }
+
+  final remainder = length % 8;
+  if (remainder != 0) {
+    final unusedBitsMask = 0xff >> remainder;
+    if (keyData.last & unusedBitsMask != 0) {
+      throw const FormatException('JWK property "k" has non-zero unused bits');
+    }
+  }
+}
+
 Future<HmacSecretKeyImpl> hmacSecretKey_importJsonWebKey(
   Map<String, dynamic> jwk,
   HashImpl hash, {
   int? length,
 }) async {
+  if (length != null && jwk['k'] is String) {
+    _checkHmacJwkLength(
+      _jwkDecodeBase64UrlNoPadding(jwk['k'] as String, 'k'),
+      length,
+    );
+  }
+
   return _HmacSecretKeyImpl(
     await _importJsonWebKey(
       jwk,
-      length == null
-          ? subtle.Algorithm(name: 'HMAC', hash: _getHashAlgorithm(hash))
-          : subtle.Algorithm(
-              name: 'HMAC',
-              hash: _getHashAlgorithm(hash),
-              length: length,
-            ),
+      subtle.Algorithm(name: 'HMAC', hash: _getHashAlgorithm(hash)),
       _usagesSignVerify,
       'secret',
     ),

--- a/lib/src/testing/regression/issue_302_hmac_jwk_length.dart
+++ b/lib/src/testing/regression/issue_302_hmac_jwk_length.dart
@@ -22,10 +22,15 @@ List<({String name, Future<void> Function() test})> tests() {
   void test(String name, Future<void> Function() fn) =>
       tests.add((name: name, test: fn));
 
-  test('Hmac: importJsonWebKey accepts matching length', () async {
-    final keyData = [0xff, 0x80];
-    final jwk = {'kty': 'oct', 'alg': 'HS256', 'k': '_4A'};
+  test('Hmac: importJsonWebKey applies length like importRawKey', () async {
+    final keyData = [0xff, 0xe0];
+    final jwk = {'kty': 'oct', 'alg': 'HS256', 'k': '_-A'};
 
+    final rawKey = await HmacSecretKey.importRawKey(
+      keyData,
+      Hash.sha256,
+      length: 9,
+    );
     final jwkKey = await HmacSecretKey.importJsonWebKey(
       jwk,
       Hash.sha256,
@@ -33,21 +38,15 @@ List<({String name, Future<void> Function() test})> tests() {
     );
 
     check(
-      equalBytes(await jwkKey.exportRawKey(), keyData),
-      'JWK import should preserve key data that matches length',
+      equalBytes(await rawKey.exportRawKey(), await jwkKey.exportRawKey()),
+      'JWK import should zero unused bits the same way as raw import',
     );
-  });
 
-  test('Hmac: importJsonWebKey rejects non-zero unused bits', () async {
-    final jwk = {'kty': 'oct', 'alg': 'HS256', 'k': '_-A'};
-
-    bool threw = false;
-    try {
-      await HmacSecretKey.importJsonWebKey(jwk, Hash.sha256, length: 9);
-    } on FormatException {
-      threw = true;
-    }
-    check(threw, 'Should throw FormatException for non-zero unused bits');
+    final data = [1, 2, 3, 4];
+    check(
+      equalBytes(await rawKey.signBytes(data), await jwkKey.signBytes(data)),
+      'JWK import should use the requested HMAC key length for signing',
+    );
   });
 
   test('Hmac: importJsonWebKey validates length', () async {

--- a/lib/src/testing/regression/issue_302_hmac_jwk_length.dart
+++ b/lib/src/testing/regression/issue_302_hmac_jwk_length.dart
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:webcrypto/webcrypto.dart';
+import '../utils/utils.dart';
+
+void main() => tests().runTests();
+
+List<({String name, Future<void> Function() test})> tests() {
+  final tests = <({String name, Future<void> Function() test})>[];
+  void test(String name, Future<void> Function() fn) =>
+      tests.add((name: name, test: fn));
+
+  test('Hmac: importJsonWebKey honors length', () async {
+    final keyData = [0xff, 0xe0];
+    final jwk = {'kty': 'oct', 'alg': 'HS256', 'k': '_-A'};
+
+    final rawKey = await HmacSecretKey.importRawKey(
+      keyData,
+      Hash.sha256,
+      length: 9,
+    );
+    final jwkKey = await HmacSecretKey.importJsonWebKey(
+      jwk,
+      Hash.sha256,
+      length: 9,
+    );
+
+    check(
+      equalBytes(await rawKey.exportRawKey(), await jwkKey.exportRawKey()),
+      'JWK import should zero unused bits the same way as raw import',
+    );
+
+    final data = [1, 2, 3, 4];
+    check(
+      equalBytes(await rawKey.signBytes(data), await jwkKey.signBytes(data)),
+      'JWK import should use the requested HMAC key length for signing',
+    );
+  });
+
+  test('Hmac: importJsonWebKey validates length', () async {
+    final jwk = {'kty': 'oct', 'alg': 'HS256', 'k': '_-A'};
+
+    bool threw = false;
+    try {
+      await HmacSecretKey.importJsonWebKey(jwk, Hash.sha256, length: 7);
+    } on ArgumentError {
+      threw = true;
+    }
+    check(threw, 'Should throw ArgumentError for invalid HMAC key length');
+  });
+
+  return tests;
+}

--- a/lib/src/testing/regression/issue_302_hmac_jwk_length.dart
+++ b/lib/src/testing/regression/issue_302_hmac_jwk_length.dart
@@ -22,15 +22,10 @@ List<({String name, Future<void> Function() test})> tests() {
   void test(String name, Future<void> Function() fn) =>
       tests.add((name: name, test: fn));
 
-  test('Hmac: importJsonWebKey honors length', () async {
-    final keyData = [0xff, 0xe0];
-    final jwk = {'kty': 'oct', 'alg': 'HS256', 'k': '_-A'};
+  test('Hmac: importJsonWebKey accepts matching length', () async {
+    final keyData = [0xff, 0x80];
+    final jwk = {'kty': 'oct', 'alg': 'HS256', 'k': '_4A'};
 
-    final rawKey = await HmacSecretKey.importRawKey(
-      keyData,
-      Hash.sha256,
-      length: 9,
-    );
     final jwkKey = await HmacSecretKey.importJsonWebKey(
       jwk,
       Hash.sha256,
@@ -38,27 +33,33 @@ List<({String name, Future<void> Function() test})> tests() {
     );
 
     check(
-      equalBytes(await rawKey.exportRawKey(), await jwkKey.exportRawKey()),
-      'JWK import should zero unused bits the same way as raw import',
-    );
-
-    final data = [1, 2, 3, 4];
-    check(
-      equalBytes(await rawKey.signBytes(data), await jwkKey.signBytes(data)),
-      'JWK import should use the requested HMAC key length for signing',
+      equalBytes(await jwkKey.exportRawKey(), keyData),
+      'JWK import should preserve key data that matches length',
     );
   });
 
-  test('Hmac: importJsonWebKey validates length', () async {
+  test('Hmac: importJsonWebKey rejects non-zero unused bits', () async {
     final jwk = {'kty': 'oct', 'alg': 'HS256', 'k': '_-A'};
 
     bool threw = false;
     try {
-      await HmacSecretKey.importJsonWebKey(jwk, Hash.sha256, length: 7);
-    } on ArgumentError {
+      await HmacSecretKey.importJsonWebKey(jwk, Hash.sha256, length: 9);
+    } on FormatException {
       threw = true;
     }
-    check(threw, 'Should throw ArgumentError for invalid HMAC key length');
+    check(threw, 'Should throw FormatException for non-zero unused bits');
+  });
+
+  test('Hmac: importJsonWebKey validates length', () async {
+    final jwk = {'kty': 'oct', 'alg': 'HS256', 'k': '_4A'};
+
+    bool threw = false;
+    try {
+      await HmacSecretKey.importJsonWebKey(jwk, Hash.sha256, length: 7);
+    } on FormatException {
+      threw = true;
+    }
+    check(threw, 'Should throw FormatException for invalid HMAC key length');
   });
 
   return tests;

--- a/lib/src/testing/testing.dart
+++ b/lib/src/testing/testing.dart
@@ -30,6 +30,7 @@ import 'webcrypto/rsassapkcs1v15.dart' as rsassapkcs1v15;
 // Other test files, that don't use TestRunner
 import 'webcrypto/random.dart' as random;
 import 'webcrypto/digest.dart' as digest;
+import 'regression/issue_302_hmac_jwk_length.dart' as issue_302_hmac_jwk_length;
 import 'regression/issue_60_trailing_bytes.dart' as issue_60_trailing_bytes;
 
 /// Test runners from all test files except `digest.dart` and
@@ -59,6 +60,7 @@ void runAllTests(
     for (final r in _testRunners) ...r.tests(),
     ...random.tests(),
     ...digest.tests(),
+    ...issue_302_hmac_jwk_length.tests(),
     ...issue_60_trailing_bytes.tests(),
   ];
 

--- a/lib/src/webcrypto/webcrypto.hmac.dart
+++ b/lib/src/webcrypto/webcrypto.hmac.dart
@@ -53,6 +53,30 @@ final class HmacSecretKey {
 
   HmacSecretKey._(this._impl); // keep the constructor private.
 
+  static void _checkLength(int length, int keyDataLength) {
+    if (length > keyDataLength * 8) {
+      throw ArgumentError.value(
+        length,
+        'length',
+        'must be less than number of bits in keyData',
+      );
+    }
+    if (length <= (keyDataLength - 1) * 8) {
+      throw ArgumentError.value(
+        length,
+        'length',
+        'must be greater than number of bits in keyData - 8, you can attain '
+            'the same effect by removing bytes from keyData',
+      );
+    }
+  }
+
+  static List<int> _decodeBase64UrlNoPadding(String unpadded) {
+    final end = unpadded.length;
+    final pad = (4 - end % 4) % 4;
+    return base64Url.decode(unpadded.padRight(end + pad, '='));
+  }
+
   /// Import [HmacSecretKey] from raw [keyData].
   ///
   /// Creates an [HmacSecretKey] using [keyData] as secret key, and running
@@ -82,20 +106,8 @@ final class HmacSecretKey {
   }) async {
     // These limitations are given in Web Cryptography Spec:
     // https://www.w3.org/TR/WebCryptoAPI/#hmac-operations
-    if (length != null && length > keyData.length * 8) {
-      throw ArgumentError.value(
-        length,
-        'length',
-        'must be less than number of bits in keyData',
-      );
-    }
-    if (length != null && length <= (keyData.length - 1) * 8) {
-      throw ArgumentError.value(
-        length,
-        'length',
-        'must be greater than number of bits in keyData - 8, you can attain '
-            'the same effect by removing bytes from keyData',
-      );
+    if (length != null) {
+      _checkLength(length, keyData.length);
     }
 
     final impl = await webCryptImpl.hmacSecretKey.importRawKey(
@@ -162,26 +174,19 @@ final class HmacSecretKey {
     Hash hash, {
     int? length,
   }) async {
-    /*
-    TODO: Validate these in the native implememtation
     // These limitations are given in Web Cryptography Spec:
     // https://www.w3.org/TR/WebCryptoAPI/#hmac-operations
-    if (length != null && length > keyData.length * 8) {
-      throw ArgumentError.value(
-          length, 'length', 'must be less than number of bits in keyData');
-    }
-    if (length != null && length <= (keyData.length - 1) * 8) {
-      throw ArgumentError.value(
+    if (length != null && jwk['k'] is String) {
+      _checkLength(
         length,
-        'length',
-        'must be greater than number of bits in keyData - 8, you can attain '
-            'the same effect by removing bytes from keyData',
+        _decodeBase64UrlNoPadding(jwk['k'] as String).length,
       );
-    }*/
+    }
 
     final impl = await webCryptImpl.hmacSecretKey.importJsonWebKey(
       jwk,
       hash._impl,
+      length: length,
     );
 
     return HmacSecretKey._(impl);

--- a/lib/src/webcrypto/webcrypto.hmac.dart
+++ b/lib/src/webcrypto/webcrypto.hmac.dart
@@ -71,12 +71,6 @@ final class HmacSecretKey {
     }
   }
 
-  static List<int> _decodeBase64UrlNoPadding(String unpadded) {
-    final end = unpadded.length;
-    final pad = (4 - end % 4) % 4;
-    return base64Url.decode(unpadded.padRight(end + pad, '='));
-  }
-
   /// Import [HmacSecretKey] from raw [keyData].
   ///
   /// Creates an [HmacSecretKey] using [keyData] as secret key, and running
@@ -174,15 +168,6 @@ final class HmacSecretKey {
     Hash hash, {
     int? length,
   }) async {
-    // These limitations are given in Web Cryptography Spec:
-    // https://www.w3.org/TR/WebCryptoAPI/#hmac-operations
-    if (length != null && jwk['k'] is String) {
-      _checkLength(
-        length,
-        _decodeBase64UrlNoPadding(jwk['k'] as String).length,
-      );
-    }
-
     final impl = await webCryptImpl.hmacSecretKey.importJsonWebKey(
       jwk,
       hash._impl,


### PR DESCRIPTION
Fixes #302.

### What changed
- Pass `length` through HMAC JWK import.
- Apply `length` after decoding `jwk.k`, matching Web Crypto HMAC import steps.
- Keep raw and JWK import behavior consistent for non-byte-aligned lengths.
- Add regression coverage for raw/JWK parity and invalid HMAC key length.

### Testing
- `/Users/apple/flutter/bin/dart run lib/src/testing/regression/issue_302_hmac_jwk_length.dart`
- `/Users/apple/flutter/bin/dart test test/webcrypto_test.dart`
- `/Users/apple/flutter/bin/dart analyze`