### PR TITLE
feat(impl_jni): add JCA AES-CBC implementation

### DIFF
--- a/example/webcrypto_demo_flutter_app/README.md
+++ b/example/webcrypto_demo_flutter_app/README.md
@@ -25,3 +25,10 @@ To run the Android JNI/JCA AES-GCM smoke test:
 flutter test integration_test/jni_aesgcm_test.dart \
   -d emulator-name
 ```
+
+To run the Android JNI/JCA AES-CBC smoke test:
+
+```sh
+flutter test integration_test/jni_aescbc_test.dart \
+  -d emulator-name
+```

--- a/example/webcrypto_demo_flutter_app/integration_test/jni_aescbc_test.dart
+++ b/example/webcrypto_demo_flutter_app/integration_test/jni_aescbc_test.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webcrypto/webcrypto.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('public API AES-128-CBC encryption matches known vector', (
+    _,
+  ) async {
+    final key = await AesCbcSecretKey.importRawKey(
+      base64Decode('nJ0IrxKwen1VN2/rfLsmmA=='),
+    );
+    final ciphertext = await key.encryptBytes(
+      base64Decode(
+        'dmVzdGlidWx1bSBsdWN0dXMgZGlhbSwgcXVpcwppbnRlcmR1bSBsZW8gYWxpcXVh'
+        'bSBhYy4gTnVuYyBhYyBtaSBpbiBs',
+      ),
+      base64Decode('AAEECRAZJDFAUWR5kKnE4Q=='),
+    );
+
+    expect(
+      base64Encode(ciphertext),
+      'MlBdzmsDQSRORkwayz7U9P7v87lgsVRRTrWsZi3qnWiqTW+m6K3KRQ4B1I1u+W7r'
+      '/kBCBQt404253SV0DeIHNe/HUesVja7CB5jvJUQ6GmQ=',
+    );
+  });
+}

--- a/lib/src/impl_jni/impl_jni.aescbc.dart
+++ b/lib/src/impl_jni/impl_jni.aescbc.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,18 +14,171 @@
 
 part of 'impl_jni.dart';
 
+const _aesCbcTransformation = 'AES/CBC/PKCS5Padding';
+
+Cipher _createAesCbcCipher(Uint8List keyData, Uint8List iv, bool isEncrypt) {
+  if (iv.length != 16) {
+    throw ArgumentError.value(iv, 'iv', 'must be 16 bytes');
+  }
+
+  return jni.using((arena) {
+    final algorithm = 'AES'.toJString()..releasedBy(arena);
+    final transformation = _aesCbcTransformation.toJString()..releasedBy(arena);
+    final keyBytes = arena.copyToJByteArray(keyData);
+    final secretKey = SecretKeySpec(keyBytes, algorithm)..releasedBy(arena);
+    final ivBytes = arena.copyToJByteArray(iv);
+    final parameters = IvParameterSpec(ivBytes)..releasedBy(arena);
+
+    final cipher = Cipher.getInstance(transformation);
+    if (cipher == null) {
+      throw operationError('JCA Cipher($_aesCbcTransformation) is unavailable');
+    }
+
+    var initialized = false;
+    try {
+      cipher.init$2(
+        isEncrypt ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE,
+        secretKey,
+        parameters,
+      );
+      initialized = true;
+    } finally {
+      if (!initialized) {
+        cipher.release();
+      }
+    }
+
+    return cipher;
+  });
+}
+
+Future<Uint8List> _aesCbcEncryptDecryptBytes(
+  Uint8List keyData,
+  List<int> data,
+  List<int> iv,
+  bool isEncrypt,
+) async {
+  Cipher? cipher;
+  try {
+    cipher = _createAesCbcCipher(keyData, _asUint8List(iv), isEncrypt);
+    return jni.using((arena) {
+      final bytes = _asUint8List(data);
+      final input = arena.copyToJByteArray(bytes);
+      final output = jni.JByteArray(cipher!.getOutputSize(bytes.length))
+        ..releasedBy(arena);
+      final outputLength = cipher.doFinal$4(input, 0, bytes.length, output);
+      return output.copyToDartBytes(length: outputLength);
+    });
+  } on OperationError {
+    rethrow;
+  } on jni.JThrowable catch (e) {
+    final message = e.message;
+    e.release();
+    throw operationError('JCA Cipher($_aesCbcTransformation) failed: $message');
+  } finally {
+    cipher?.release();
+  }
+}
+
+Stream<Uint8List> _aesCbcEncryptDecryptStream(
+  Uint8List keyData,
+  Stream<List<int>> data,
+  List<int> iv,
+  bool isEncrypt,
+) async* {
+  final arena = jni.Arena();
+  Cipher? cipher;
+  try {
+    cipher = _createAesCbcCipher(keyData, _asUint8List(iv), isEncrypt);
+    final inputBuffer = jni.JByteArray(_defaultChunkSize)..releasedBy(arena);
+    final outputBuffer = jni.JByteArray(cipher.getOutputSize(_defaultChunkSize))
+      ..releasedBy(arena);
+
+    await for (final chunk in data) {
+      final bytes = _asUint8List(chunk);
+      var offset = 0;
+      while (offset < bytes.length) {
+        final remaining = bytes.length - offset;
+        final length = remaining < _defaultChunkSize
+            ? remaining
+            : _defaultChunkSize;
+
+        inputBuffer.setRange(0, length, bytes, offset);
+        final outputLength = cipher.update$2(
+          inputBuffer,
+          0,
+          length,
+          outputBuffer,
+        );
+        if (outputLength > 0) {
+          yield outputBuffer.copyToDartBytes(length: outputLength);
+        }
+        offset += length;
+      }
+    }
+
+    final outputLength = cipher.doFinal$4(inputBuffer, 0, 0, outputBuffer);
+    if (outputLength > 0) {
+      yield outputBuffer.copyToDartBytes(length: outputLength);
+    }
+  } on OperationError {
+    rethrow;
+  } on jni.JThrowable catch (e) {
+    final message = e.message;
+    e.release();
+    throw operationError('JCA Cipher($_aesCbcTransformation) failed: $message');
+  } finally {
+    cipher?.release();
+    arena.releaseAll();
+  }
+}
+
 final class _StaticAesCbcSecretKeyImpl implements StaticAesCbcSecretKeyImpl {
   const _StaticAesCbcSecretKeyImpl();
 
   @override
-  Future<AesCbcSecretKeyImpl> importRawKey(List<int> keyData) =>
-      throw UnimplementedError('Not implemented');
+  Future<AesCbcSecretKeyImpl> importRawKey(List<int> keyData) async =>
+      _AesCbcSecretKeyImpl(_aesImportRawKey(keyData));
 
   @override
-  Future<AesCbcSecretKeyImpl> importJsonWebKey(Map<String, dynamic> jwk) =>
-      throw UnimplementedError('Not implemented');
+  Future<AesCbcSecretKeyImpl> importJsonWebKey(
+    Map<String, dynamic> jwk,
+  ) async =>
+      _AesCbcSecretKeyImpl(_aesImportJwkKey(jwk, expectedJwkAlgSuffix: 'CBC'));
 
   @override
-  Future<AesCbcSecretKeyImpl> generateKey(int length) =>
-      throw UnimplementedError('Not implemented');
+  Future<AesCbcSecretKeyImpl> generateKey(int length) async =>
+      _AesCbcSecretKeyImpl(_aesGenerateKey(length));
+}
+
+final class _AesCbcSecretKeyImpl implements AesCbcSecretKeyImpl {
+  _AesCbcSecretKeyImpl(this._keyData);
+
+  final Uint8List _keyData;
+
+  @override
+  String toString() => 'Instance of \'AesCbcSecretKey\'';
+
+  @override
+  Future<Uint8List> encryptBytes(List<int> data, List<int> iv) async =>
+      _aesCbcEncryptDecryptBytes(_keyData, data, iv, true);
+
+  @override
+  Future<Uint8List> decryptBytes(List<int> data, List<int> iv) async =>
+      _aesCbcEncryptDecryptBytes(_keyData, data, iv, false);
+
+  @override
+  Stream<Uint8List> encryptStream(Stream<List<int>> data, List<int> iv) =>
+      _aesCbcEncryptDecryptStream(_keyData, data, iv, true);
+
+  @override
+  Stream<Uint8List> decryptStream(Stream<List<int>> data, List<int> iv) =>
+      _aesCbcEncryptDecryptStream(_keyData, data, iv, false);
+
+  @override
+  Future<Uint8List> exportRawKey() async => Uint8List.fromList(_keyData);
+
+  @override
+  Future<Map<String, dynamic>> exportJsonWebKey() async =>
+      _aesExportJwkKey(_keyData, jwkAlgSuffix: 'CBC');
 }

--- a/lib/src/impl_jni/impl_jni.aescbc.dart
+++ b/lib/src/impl_jni/impl_jni.aescbc.dart
@@ -72,9 +72,7 @@ Future<Uint8List> _aesCbcEncryptDecryptBytes(
   } on OperationError {
     rethrow;
   } on jni.JThrowable catch (e) {
-    final message = e.message;
-    e.release();
-    throw operationError('JCA Cipher($_aesCbcTransformation) failed: $message');
+    throw _aesCbcOperationError(e);
   } finally {
     cipher?.release();
   }
@@ -124,13 +122,21 @@ Stream<Uint8List> _aesCbcEncryptDecryptStream(
   } on OperationError {
     rethrow;
   } on jni.JThrowable catch (e) {
-    final message = e.message;
-    e.release();
-    throw operationError('JCA Cipher($_aesCbcTransformation) failed: $message');
+    throw _aesCbcOperationError(e);
   } finally {
     cipher?.release();
     arena.releaseAll();
   }
+}
+
+OperationError _aesCbcOperationError(jni.JThrowable throwable) {
+  late final String message;
+  try {
+    message = throwable.message;
+  } finally {
+    throwable.release();
+  }
+  return operationError('JCA Cipher($_aesCbcTransformation) failed: $message');
 }
 
 final class _StaticAesCbcSecretKeyImpl implements StaticAesCbcSecretKeyImpl {

--- a/lib/src/impl_jni/impl_jni.utils.dart
+++ b/lib/src/impl_jni/impl_jni.utils.dart
@@ -71,8 +71,10 @@ extension _JniArenaByteArray on jni.Arena {
 
 extension _JByteArrayCopy on jni.JByteArray {
   /// Copies this JVM byte array into Dart-owned memory.
-  Uint8List copyToDartBytes() {
-    final bytes = getRange(0, length);
+  Uint8List copyToDartBytes({int? length}) {
+    final byteCount = length ?? this.length;
+    RangeError.checkValueInInterval(byteCount, 0, this.length, 'length');
+    final bytes = getRange(0, byteCount);
     final view = Uint8List.sublistView(bytes);
     return Uint8List.fromList(view);
   }

--- a/test/impl_jni_aescbc_test.dart
+++ b/test/impl_jni_aescbc_test.dart
@@ -1,0 +1,159 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:webcrypto/src/impl_interface/impl_interface.dart';
+import 'package:webcrypto/src/impl_ffi/impl_ffi.dart' as ffi_impl;
+import 'package:webcrypto/src/impl_jni/impl_jni.dart' as jni_impl;
+
+import 'src/jni_test_setup.dart'
+    if (dart.library.io) 'src/jni_test_setup_io.dart';
+
+void main() {
+  final skipReason = jniHelperSetupSkipReason;
+
+  setUpAll(() {
+    if (skipReason != null) {
+      return;
+    }
+
+    spawnJniForDesktopTests();
+  });
+
+  test('JCA AES-128-CBC encrypts and decrypts a known vector', () async {
+    final keyData = base64Decode('nJ0IrxKwen1VN2/rfLsmmA==');
+    final iv = base64Decode('AAEECRAZJDFAUWR5kKnE4Q==');
+    final plaintext = base64Decode(
+      'dmVzdGlidWx1bSBsdWN0dXMgZGlhbSwgcXVpcwppbnRlcmR1bSBsZW8gYWxpcXVh'
+      'bSBhYy4gTnVuYyBhYyBtaSBpbiBs',
+    );
+    final expectedCiphertext = base64Decode(
+      'MlBdzmsDQSRORkwayz7U9P7v87lgsVRRTrWsZi3qnWiqTW+m6K3KRQ4B1I1u+W7r'
+      '/kBCBQt404253SV0DeIHNe/HUesVja7CB5jvJUQ6GmQ=',
+    );
+
+    final key = await jni_impl.webCryptImpl.aesCbcSecretKey.importRawKey(
+      keyData,
+    );
+    final ciphertext = await key.encryptBytes(plaintext, iv);
+
+    final ffiKey = await ffi_impl.webCryptImpl.aesCbcSecretKey.importRawKey(
+      keyData,
+    );
+    final ffiCiphertext = await ffiKey.encryptBytes(plaintext, iv);
+
+    expect(ciphertext, expectedCiphertext);
+    expect(ciphertext, ffiCiphertext);
+    expect(await key.decryptBytes(ciphertext, iv), plaintext);
+  }, skip: skipReason);
+
+  test('JCA AES-256-CBC stream encryption matches FFI', () async {
+    final keyData = base64Decode(
+      'b0y6+MqS0ShCvZiloJJAeG8ei8tVIN3OCYIdn1FN74o=',
+    );
+    final iv = base64Decode('AAEECRAZJDFAUWR5kKnE4Q==');
+    final chunks = [
+      utf8.encode('vestibulum vestibulum '),
+      utf8.encode('luctus diam, quis '),
+      utf8.encode('aliquam.'),
+    ];
+
+    final key = await jni_impl.webCryptImpl.aesCbcSecretKey.importRawKey(
+      keyData,
+    );
+    final ciphertext = await _collectBytes(
+      key.encryptStream(Stream.fromIterable(chunks), iv),
+    );
+
+    final ffiKey = await ffi_impl.webCryptImpl.aesCbcSecretKey.importRawKey(
+      keyData,
+    );
+    final ffiCiphertext = await _collectBytes(
+      ffiKey.encryptStream(Stream.fromIterable(chunks), iv),
+    );
+
+    expect(ciphertext, ffiCiphertext);
+    expect(
+      await _collectBytes(key.decryptStream(Stream.value(ciphertext), iv)),
+      chunks.expand((chunk) => chunk),
+    );
+  }, skip: skipReason);
+
+  test('JCA AES-CBC exports and imports JSON Web Keys', () async {
+    final keyData = Uint8List.fromList(List<int>.generate(32, (i) => i));
+    final key = await jni_impl.webCryptImpl.aesCbcSecretKey.importRawKey(
+      keyData,
+    );
+
+    final jwk = await key.exportJsonWebKey();
+    expect(jwk['kty'], 'oct');
+    expect(jwk['use'], 'enc');
+    expect(jwk['alg'], 'A256CBC');
+
+    final imported = await jni_impl.webCryptImpl.aesCbcSecretKey
+        .importJsonWebKey(jwk);
+
+    expect(await imported.exportRawKey(), keyData);
+  }, skip: skipReason);
+
+  test('JCA AES-CBC generateKey creates 128 and 256 bit keys', () async {
+    final key128 = await jni_impl.webCryptImpl.aesCbcSecretKey.generateKey(128);
+    final key256 = await jni_impl.webCryptImpl.aesCbcSecretKey.generateKey(256);
+
+    expect(await key128.exportRawKey(), hasLength(16));
+    expect(await key256.exportRawKey(), hasLength(32));
+  }, skip: skipReason);
+
+  test('JCA AES-CBC rejects invalid IV length as ArgumentError', () async {
+    final key = await jni_impl.webCryptImpl.aesCbcSecretKey.importRawKey(
+      Uint8List(16),
+    );
+
+    await expectLater(
+      key.encryptBytes(Uint8List(16), Uint8List(15)),
+      throwsA(isA<ArgumentError>()),
+    );
+  }, skip: skipReason);
+
+  test('JCA AES-CBC translates invalid padding to OperationError', () async {
+    final keyData = base64Decode('nJ0IrxKwen1VN2/rfLsmmA==');
+    final iv = base64Decode('AAEECRAZJDFAUWR5kKnE4Q==');
+    final key = await jni_impl.webCryptImpl.aesCbcSecretKey.importRawKey(
+      keyData,
+    );
+    final ciphertext = Uint8List.fromList(
+      await key.encryptBytes(utf8.encode('padding check'), iv),
+    );
+    ciphertext[ciphertext.length - 1] ^= 0x01;
+
+    await expectLater(
+      key.decryptBytes(ciphertext, iv),
+      throwsA(isA<OperationError>()),
+    );
+  }, skip: skipReason);
+}
+
+Future<Uint8List> _collectBytes(Stream<List<int>> stream) async {
+  final builder = BytesBuilder(copy: false);
+  await for (final chunk in stream) {
+    builder.add(chunk);
+  }
+  return builder.takeBytes();
+}


### PR DESCRIPTION
## Summary

Adds the JNI/JCA AES-CBC implementation on top of the existing Android JCA backend skeleton.

This PR implements:
- AES-CBC raw key import/export
- AES-CBC JWK import/export
- AES-CBC key generation using the shared AES helper
- byte and stream encryption/decryption
- JCA `Cipher("AES/CBC/PKCS5Padding")` wiring with `IvParameterSpec`
- focused desktop JNI tests
- Android integration smoke test through the public API

`PKCS5Padding` is the JCA transformation name used for AES-CBC PKCS#7-style block padding.

## Testing

For the desktop JNI-specific test, run this once first if JNI has not been set up locally:
- `dart run jni:setup`

Verified with:
- `dart analyze`
- `dart test test/impl_jni_aescbc_test.dart`
- `dart test test/webcrypto_test.dart -p vm -n AES-CBC`
- `flutter test integration_test/jni_aescbc_test.dart -d emulator-name`