### PR TITLE
refactor(js): fix JSDomException checks for wasm compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.6.2-wip
+* Fixed JS interop to enable WebAssembly.
+
 # 0.6.1
 * Added Dart native build hooks and native asset lookup for the bundled
   native library, enabling `dart test` for the core package.

--- a/lib/src/crypto_subtle.dart
+++ b/lib/src/crypto_subtle.dart
@@ -14,7 +14,7 @@
 
 /// This library attempts to expose the definitions necessary to use the
 /// browsers `window.crypto.subtle` APIs.
-library common;
+library;
 
 import 'dart:js_interop';
 import 'dart:typed_data';

--- a/lib/src/impl_ffi/impl_ffi.dart
+++ b/lib/src/impl_ffi/impl_ffi.dart
@@ -14,7 +14,7 @@
 
 // ignore_for_file: non_constant_identifier_names
 
-library impl_ffi;
+library;
 
 import 'dart:async';
 import 'dart:ffi' show Allocator;

--- a/lib/src/impl_interface/impl_interface.dart
+++ b/lib/src/impl_interface/impl_interface.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library impl_stub;
+library;
 
 import 'dart:typed_data';
 import 'dart:async';

--- a/lib/src/impl_js/impl_js.dart
+++ b/lib/src/impl_js/impl_js.dart
@@ -15,6 +15,7 @@
 library impl_js;
 
 import 'dart:async';
+import 'dart:js_interop';
 import 'dart:typed_data';
 
 import 'package:webcrypto/src/impl_interface/impl_interface.dart';

--- a/lib/src/impl_js/impl_js.dart
+++ b/lib/src/impl_js/impl_js.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library impl_js;
+library;
 
 import 'dart:async';
 import 'dart:js_interop';

--- a/lib/src/impl_js/impl_js.random.dart
+++ b/lib/src/impl_js/impl_js.random.dart
@@ -22,8 +22,8 @@ final class _RandomImpl implements RandomImpl {
     try {
       subtle.getRandomValues(destination);
     } catch (e) {
-      final jsError = e as JSAny?;
-      if (jsError != null && jsError.isA<subtle.JSDomException>()) {
+      // ignore: invalid_runtime_check_with_js_interop_types
+      if (e is JSAny && e.isA<subtle.JSDomException>()) {
         throw _translateDomException(e as subtle.JSDomException);
       }
       if (e is Error) {

--- a/lib/src/impl_js/impl_js.random.dart
+++ b/lib/src/impl_js/impl_js.random.dart
@@ -21,15 +21,20 @@ final class _RandomImpl implements RandomImpl {
   void fillRandomBytes(TypedData destination) {
     try {
       subtle.getRandomValues(destination);
-    } on subtle.JSDomException catch (e) {
-      throw _translateDomException(e);
-    } on Error catch (e) {
-      final errorName = e.toString();
-      if (errorName != 'JavaScriptError') {
-        rethrow;
+    } catch (e) {
+      final jsError = e as JSAny?;
+      if (jsError != null && jsError.isA<subtle.JSDomException>()) {
+        throw _translateDomException(e as subtle.JSDomException);
       }
+      if (e is Error) {
+        final errorName = e.toString();
+        if (errorName != 'JavaScriptError') {
+          rethrow;
+        }
 
-      throw _translateJavaScriptException();
+        throw _translateJavaScriptException();
+      }
+      rethrow;
     }
   }
 }

--- a/lib/src/impl_js/impl_js.utils.dart
+++ b/lib/src/impl_js/impl_js.utils.dart
@@ -132,10 +132,10 @@ Future<T> _handleDomException<T>(
   try {
     return await fn();
   } catch (e) {
-    final jsError = e as JSAny?;
-    if (jsError != null && jsError.isA<subtle.JSDomException>()) {
+    // ignore: invalid_runtime_check_with_js_interop_types
+    if (e is JSAny && e.isA<subtle.JSDomException>()) {
       throw _translateDomException(
-        jsError as subtle.JSDomException,
+        e as subtle.JSDomException,
         invalidAccessErrorIsArgumentError: invalidAccessErrorIsArgumentError,
       );
     }

--- a/lib/src/impl_js/impl_js.utils.dart
+++ b/lib/src/impl_js/impl_js.utils.dart
@@ -131,11 +131,15 @@ Future<T> _handleDomException<T>(
 }) async {
   try {
     return await fn();
-  } on subtle.JSDomException catch (e) {
-    throw _translateDomException(
-      e,
-      invalidAccessErrorIsArgumentError: invalidAccessErrorIsArgumentError,
-    );
+  } catch (e) {
+    final jsError = e as JSAny?;
+    if (jsError != null && jsError.isA<subtle.JSDomException>()) {
+      throw _translateDomException(
+        jsError as subtle.JSDomException,
+        invalidAccessErrorIsArgumentError: invalidAccessErrorIsArgumentError,
+      );
+    }
+    rethrow;
   }
 }
 

--- a/lib/src/impl_stub/impl_stub.dart
+++ b/lib/src/impl_stub/impl_stub.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library webcrypto.impl_stub;
+library;
 
 import 'dart:typed_data';
 

--- a/lib/src/testing/webcrypto/aesctr.dart
+++ b/lib/src/testing/webcrypto/aesctr.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library aesctr_test;
+library;
 
 import 'package:webcrypto/webcrypto.dart';
 import '../utils/utils.dart';

--- a/lib/src/webcrypto/webcrypto.dart
+++ b/lib/src/webcrypto/webcrypto.dart
@@ -18,7 +18,7 @@
 ///       expect that the contents of these streams is buffered when operating
 ///       in the browser.
 ///       This could be documented for each method or at library level.
-library webcrypto;
+library;
 
 import 'dart:convert';
 import 'dart:async';

--- a/lib/webcrypto.dart
+++ b/lib/webcrypto.dart
@@ -43,6 +43,6 @@
 ///     mismatching curves where it becomes an [ArgumentError].
 ///
 /// @docImport 'src/webcrypto/webcrypto.dart';
-library webcrypto;
+library;
 
 export 'src/webcrypto/webcrypto.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: webcrypto
-version: 0.6.1
+version: 0.6.2-wip
 description: Cross-platform implementation of Web Cryptography APIs for Dart.
 repository: https://github.com/google/webcrypto.dart
 

--- a/test/crypto_subtle_test.dart
+++ b/test/crypto_subtle_test.dart
@@ -168,10 +168,10 @@ void main() {
       try {
         subtle.window.crypto.getRandomValues(Uint8List(1000000).toJS);
       } catch (e) {
-        final jsError = e as JSAny?;
-        if (jsError != null && jsError.isA<subtle.JSDomException>()) {
+        // ignore: invalid_runtime_check_with_js_interop_types
+        if (e is JSAny && e.isA<subtle.JSDomException>()) {
           // dart2js throws QuotaExceededError
-          expect((jsError as subtle.JSDomException).name, 'QuotaExceededError');
+          expect((e as subtle.JSDomException).name, 'QuotaExceededError');
         } else if (e is Error) {
           expect(
             e.toString(),
@@ -187,10 +187,10 @@ void main() {
       try {
         subtle.window.crypto.getRandomValues(Float32List(32).toJS);
       } catch (e) {
-        final jsError = e as JSAny?;
-        if (jsError != null && jsError.isA<subtle.JSDomException>()) {
+        // ignore: invalid_runtime_check_with_js_interop_types
+        if (e is JSAny && e.isA<subtle.JSDomException>()) {
           // dart2js throws TypeMismatchError
-          expect((jsError as subtle.JSDomException).name, 'TypeMismatchError');
+          expect((e as subtle.JSDomException).name, 'TypeMismatchError');
         } else if (e is Error) {
           expect(
             e.toString(),

--- a/test/crypto_subtle_test.dart
+++ b/test/crypto_subtle_test.dart
@@ -167,28 +167,38 @@ void main() {
     test('getRandomValues: too long', () {
       try {
         subtle.window.crypto.getRandomValues(Uint8List(1000000).toJS);
-      } on subtle.JSDomException catch (e) {
-        // dart2js throws QuotaExceededError
-        expect(e.name, 'QuotaExceededError');
-      } on Error catch (e) {
-        expect(
-          e.toString(),
-          anyOf('JavaScriptError', startsWith('QuotaExceededError:')),
-        );
+      } catch (e) {
+        final jsError = e as JSAny?;
+        if (jsError != null && jsError.isA<subtle.JSDomException>()) {
+          // dart2js throws QuotaExceededError
+          expect((jsError as subtle.JSDomException).name, 'QuotaExceededError');
+        } else if (e is Error) {
+          expect(
+            e.toString(),
+            anyOf('JavaScriptError', startsWith('QuotaExceededError:')),
+          );
+        } else {
+          rethrow;
+        }
       }
     });
 
     test('getRandomValues: not supported type', () {
       try {
         subtle.window.crypto.getRandomValues(Float32List(32).toJS);
-      } on subtle.JSDomException catch (e) {
-        // dart2js throws TypeMismatchError
-        expect(e.name, 'TypeMismatchError');
-      } on Error catch (e) {
-        expect(
-          e.toString(),
-          anyOf('JavaScriptError', startsWith('TypeMismatchError:')),
-        );
+      } catch (e) {
+        final jsError = e as JSAny?;
+        if (jsError != null && jsError.isA<subtle.JSDomException>()) {
+          // dart2js throws TypeMismatchError
+          expect((jsError as subtle.JSDomException).name, 'TypeMismatchError');
+        } else if (e is Error) {
+          expect(
+            e.toString(),
+            anyOf('JavaScriptError', startsWith('TypeMismatchError:')),
+          );
+        } else {
+          rethrow;
+        }
       }
     });
   });


### PR DESCRIPTION
Resolve invalid_runtime_check_with_js_interop_types warnings for JSDomException.

Instead of directly catching the extension type JSDomException or checking e is JSObject, we catch generic objects, cast them to JSAny?, and check if they are JSDomException instances using isA<subtle.JSDomException>().

This avoids platform-inconsistent runtime checks that behave incorrectly under dart2wasm where extension types are runtime-erased.