### PR TITLE
Fix AES-CTR large chunk handling

### DIFF
--- a/lib/src/impl_ffi/impl_ffi.aesctr.dart
+++ b/lib/src/impl_ffi/impl_ffi.aesctr.dart
@@ -140,7 +140,7 @@ Stream<Uint8List> _aesCtrEncryptOrDecrypt(
         // Consume the first M bytes from data.
         var i = 0; // Number of bytes consumed, after offset
         while (i < M) {
-          final N = math.min(M, bufSize);
+          final N = math.min(M - i, bufSize);
           inData.setAll(0, data.skip(offset + i).take(N));
 
           _checkOpIsOne(ssl.EVP_CipherUpdate(ctx, outBuf, outLen, inBuf, N));

--- a/test/aes_ctr_counter_wrap_test.dart
+++ b/test/aes_ctr_counter_wrap_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:test/test.dart';
@@ -36,5 +37,22 @@ void main() {
     final ciphertextB = await key.encryptBytes(Uint8List(16), counterB, 32);
 
     expect(ciphertextA.sublist(16, 32), isNot(equals(ciphertextB)));
+  });
+
+  test('AES-CTR handles input larger than the internal buffer', () async {
+    final key = await AesCtrSecretKey.importRawKey(Uint8List(16));
+    final plaintext = Uint8List(4097);
+    final counter = Uint8List(16);
+
+    final ciphertext = await key.encryptBytes(plaintext, counter, 128);
+    final decrypted = await key.decryptBytes(ciphertext, counter, 128);
+    final streamedCiphertext = await key
+        .encryptStream(Stream.value(plaintext), counter, 128)
+        .expand((chunk) => chunk)
+        .toList();
+
+    expect(ciphertext, hasLength(plaintext.length));
+    expect(decrypted, equals(plaintext));
+    expect(streamedCiphertext, equals(ciphertext));
   });
 }


### PR DESCRIPTION
Fixes #307.

### Summary

- account for bytes already consumed when selecting the next AES-CTR input chunk
- add regression coverage for a 4097-byte input
- verify byte encryption/decryption round-trips and matches streaming encryption

### Testing

- `dart format --output none --set-exit-if-changed lib/src/impl_ffi/impl_ffi.aesctr.dart test/aes_ctr_counter_wrap_test.dart`
- `dart analyze --fatal-warnings .`
- `dart test -p vm test/aes_ctr_counter_wrap_test.dart`
- `dart test -p chrome test/aes_ctr_counter_wrap_test.dart`
- `dart test -p vm`
