### PR TITLE
feat(impl_jni): add JCA AES-CTR implementation

### DIFF
--- a/example/webcrypto_demo_flutter_app/README.md
+++ b/example/webcrypto_demo_flutter_app/README.md
@@ -32,3 +32,10 @@ To run the Android JNI/JCA AES-CBC smoke test:
 flutter test integration_test/jni_aescbc_test.dart \
   -d emulator-name
 ```
+
+To run the Android JNI/JCA AES-CTR smoke test:
+
+```sh
+flutter test integration_test/jni_aesctr_test.dart \
+  -d emulator-name
+```

--- a/example/webcrypto_demo_flutter_app/integration_test/jni_aesctr_test.dart
+++ b/example/webcrypto_demo_flutter_app/integration_test/jni_aesctr_test.dart
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webcrypto/webcrypto.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('public API AES-128-CTR encryption matches known vector', (
+    _,
+  ) async {
+    final key = await AesCtrSecretKey.importRawKey(
+      base64Decode('VPhdE6z4820SUnBmesDBSw=='),
+    );
+    final plaintext = base64Decode(
+      'dXJpcyBxdWlzIG1hdHRpcyBtYXNzYS4gUGhhc2VsbHVzIGNvbnZhbGxp',
+    );
+    final counter = base64Decode('AAEECRAZJDFAUWR5kKnE4Q==');
+    final ciphertext = await key.encryptBytes(plaintext, counter, 64);
+
+    expect(
+      base64Encode(ciphertext),
+      'LnHSulNxQ6y+Z2rC2g8QQURwQWrI53qMPajfaef3cA0jaL+yAd3syGfz',
+    );
+    expect(await key.decryptBytes(ciphertext, counter, 64), plaintext);
+  });
+}

--- a/lib/src/impl_jni/impl_jni.aesctr.dart
+++ b/lib/src/impl_jni/impl_jni.aesctr.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,18 +14,264 @@
 
 part of 'impl_jni.dart';
 
+const _aesCtrTransformation = 'AES/CTR/NoPadding';
+const _aesBlockSize = 16;
+
+Stream<Uint8List> _aesCtrEncryptDecrypt(
+  Uint8List keyData,
+  Stream<List<int>> data,
+  Uint8List counter,
+  int length,
+  bool isEncrypt,
+) async* {
+  final initialCounter = Uint8List.fromList(counter);
+  final counterValue = _parseAesCtrCounter(initialCounter, length);
+  final counterValues = BigInt.one << length;
+  var bytesUntilWraparound =
+      (counterValues - counterValue) * BigInt.from(_aesBlockSize);
+  var bytesAfterWraparound = counterValue * BigInt.from(_aesBlockSize);
+  var isBeforeWraparound = true;
+
+  final arena = jni.Arena();
+  try {
+    var cipher = _createAesCtrCipher(arena, keyData, initialCounter, isEncrypt);
+    final inputBuffer = jni.JByteArray(_defaultChunkSize)..releasedBy(arena);
+    final outputBuffer = jni.JByteArray(_defaultChunkSize)..releasedBy(arena);
+
+    await for (final chunk in data) {
+      final bytes = _asUint8List(chunk);
+      var offset = 0;
+      while (offset < bytes.length) {
+        final remaining = bytes.length - offset;
+        final segmentLength = isBeforeWraparound
+            ? _minBigIntAndInt(bytesUntilWraparound, remaining)
+            : remaining;
+
+        if (isBeforeWraparound) {
+          bytesUntilWraparound -= BigInt.from(segmentLength);
+        } else if (bytesAfterWraparound < BigInt.from(segmentLength)) {
+          throw const FormatException(
+            'input is too large for the counter length',
+          );
+        } else {
+          bytesAfterWraparound -= BigInt.from(segmentLength);
+        }
+
+        var consumed = 0;
+        while (consumed < segmentLength) {
+          final chunkLength = math.min(
+            _defaultChunkSize,
+            segmentLength - consumed,
+          );
+          inputBuffer.setRange(0, chunkLength, bytes, offset + consumed);
+          final outputLength = cipher.update$2(
+            inputBuffer,
+            0,
+            chunkLength,
+            outputBuffer,
+          );
+          if (outputLength > 0) {
+            yield outputBuffer.copyToDartBytes(length: outputLength);
+          }
+          consumed += chunkLength;
+        }
+        offset += segmentLength;
+
+        if (isBeforeWraparound && bytesUntilWraparound == BigInt.zero) {
+          final finalOutput = cipher.doFinal();
+          if (finalOutput != null) {
+            finalOutput.releasedBy(arena);
+            if (finalOutput.length > 0) {
+              yield finalOutput.copyToDartBytes();
+            }
+          }
+
+          cipher = _createAesCtrCipher(
+            arena,
+            keyData,
+            _wrapAesCtrCounter(initialCounter, length),
+            isEncrypt,
+          );
+          isBeforeWraparound = false;
+        }
+      }
+    }
+
+    final finalOutput = cipher.doFinal();
+    if (finalOutput != null) {
+      finalOutput.releasedBy(arena);
+      if (finalOutput.length > 0) {
+        yield finalOutput.copyToDartBytes();
+      }
+    }
+  } on jni.JThrowable catch (e) {
+    throw _aesCtrOperationError(e);
+  } finally {
+    arena.releaseAll();
+  }
+}
+
+Cipher _createAesCtrCipher(
+  jni.Arena arena,
+  Uint8List keyData,
+  Uint8List counter,
+  bool isEncrypt,
+) {
+  final algorithm = 'AES'.toJString()..releasedBy(arena);
+  final transformation = _aesCtrTransformation.toJString()..releasedBy(arena);
+  final keyBytes = arena.copyToJByteArray(keyData);
+  final secretKey = SecretKeySpec(keyBytes, algorithm)..releasedBy(arena);
+  final counterBytes = arena.copyToJByteArray(counter);
+  final parameters = IvParameterSpec(counterBytes)..releasedBy(arena);
+
+  final cipher = Cipher.getInstance(transformation);
+  if (cipher == null) {
+    throw operationError('JCA Cipher($_aesCtrTransformation) is unavailable');
+  }
+  cipher.releasedBy(arena);
+  cipher.init$2(
+    isEncrypt ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE,
+    secretKey,
+    parameters,
+  );
+  return cipher;
+}
+
+BigInt _parseAesCtrCounter(Uint8List counter, int length) {
+  final byteCount = (length + 7) ~/ 8;
+  final start = counter.length - byteCount;
+  final remainder = length % 8;
+
+  var value = BigInt.zero;
+  for (var i = start; i < counter.length; i++) {
+    var byte = counter[i] & 0xff;
+    if (i == start && remainder != 0) {
+      byte &= (1 << remainder) - 1;
+    }
+    value = (value << 8) | BigInt.from(byte);
+  }
+  return value;
+}
+
+Uint8List _wrapAesCtrCounter(Uint8List counter, int length) {
+  final wrapped = Uint8List.fromList(counter);
+  final counterBytes = length ~/ 8;
+  if (counterBytes > 0) {
+    wrapped.fillRange(wrapped.length - counterBytes, wrapped.length, 0);
+  }
+  final remainder = length % 8;
+  if (remainder != 0) {
+    final index = wrapped.length - counterBytes - 1;
+    wrapped[index] &= 0xff & (0xff << remainder);
+  }
+  return wrapped;
+}
+
+int _minBigIntAndInt(BigInt value, int limit) {
+  // Avoid converting huge counter-space values, such as 2^128, 
+  // to int just to compare them with the current Dart chunk length.
+  final bigLimit = BigInt.from(limit);
+  return value < bigLimit ? value.toInt() : limit;
+}
+
+OperationError _aesCtrOperationError(jni.JThrowable throwable) {
+  late final String message;
+  try {
+    message = throwable.message;
+  } finally {
+    throwable.release();
+  }
+  return operationError('JCA Cipher($_aesCtrTransformation) failed: $message');
+}
+
 final class _StaticAesCtrSecretKeyImpl implements StaticAesCtrSecretKeyImpl {
   const _StaticAesCtrSecretKeyImpl();
 
   @override
-  Future<AesCtrSecretKeyImpl> importRawKey(List<int> keyData) =>
-      throw UnimplementedError('Not implemented');
+  Future<AesCtrSecretKeyImpl> importRawKey(List<int> keyData) async =>
+      _AesCtrSecretKeyImpl(_aesImportRawKey(keyData));
 
   @override
-  Future<AesCtrSecretKeyImpl> importJsonWebKey(Map<String, dynamic> jwk) =>
-      throw UnimplementedError('Not implemented');
+  Future<AesCtrSecretKeyImpl> importJsonWebKey(
+    Map<String, dynamic> jwk,
+  ) async =>
+      _AesCtrSecretKeyImpl(_aesImportJwkKey(jwk, expectedJwkAlgSuffix: 'CTR'));
 
   @override
-  Future<AesCtrSecretKeyImpl> generateKey(int length) =>
-      throw UnimplementedError('Not implemented');
+  Future<AesCtrSecretKeyImpl> generateKey(int length) async =>
+      _AesCtrSecretKeyImpl(_aesGenerateKey(length));
+}
+
+final class _AesCtrSecretKeyImpl implements AesCtrSecretKeyImpl {
+  _AesCtrSecretKeyImpl(this._keyData);
+
+  final Uint8List _keyData;
+
+  @override
+  Future<Uint8List> encryptBytes(
+    List<int> data,
+    List<int> counter,
+    int length,
+  ) async {
+    _checkArguments(counter, length);
+    return _bufferStream(encryptStream(Stream.value(data), counter, length));
+  }
+
+  @override
+  Future<Uint8List> decryptBytes(
+    List<int> data,
+    List<int> counter,
+    int length,
+  ) async {
+    _checkArguments(counter, length);
+    return _bufferStream(decryptStream(Stream.value(data), counter, length));
+  }
+
+  @override
+  Stream<Uint8List> encryptStream(
+    Stream<List<int>> data,
+    List<int> counter,
+    int length,
+  ) {
+    _checkArguments(counter, length);
+    return _aesCtrEncryptDecrypt(
+      _keyData,
+      data,
+      Uint8List.fromList(counter),
+      length,
+      true,
+    );
+  }
+
+  @override
+  Stream<Uint8List> decryptStream(
+    Stream<List<int>> data,
+    List<int> counter,
+    int length,
+  ) {
+    _checkArguments(counter, length);
+    return _aesCtrEncryptDecrypt(
+      _keyData,
+      data,
+      Uint8List.fromList(counter),
+      length,
+      false,
+    );
+  }
+
+  @override
+  Future<Uint8List> exportRawKey() async => Uint8List.fromList(_keyData);
+
+  @override
+  Future<Map<String, dynamic>> exportJsonWebKey() async =>
+      _aesExportJwkKey(_keyData, jwkAlgSuffix: 'CTR');
+
+  void _checkArguments(List<int> counter, int length) {
+    if (counter.length != 16) {
+      throw ArgumentError.value(counter, 'counter', 'must be 16 bytes');
+    }
+    if (length <= 0 || 128 < length) {
+      throw ArgumentError.value(length, 'length', 'must be between 1 and 128');
+    }
+  }
 }

--- a/lib/src/impl_jni/impl_jni.aesctr.dart
+++ b/lib/src/impl_jni/impl_jni.aesctr.dart
@@ -168,7 +168,7 @@ Uint8List _wrapAesCtrCounter(Uint8List counter, int length) {
 }
 
 int _minBigIntAndInt(BigInt value, int limit) {
-  // Avoid converting huge counter-space values, such as 2^128, 
+  // Avoid converting huge counter-space values, such as 2^128,
   // to int just to compare them with the current Dart chunk length.
   final bigLimit = BigInt.from(limit);
   return value < bigLimit ? value.toInt() : limit;

--- a/lib/src/impl_jni/impl_jni.dart
+++ b/lib/src/impl_jni/impl_jni.dart
@@ -21,6 +21,7 @@ library;
 
 import 'dart:async';
 import 'dart:convert' show base64Url;
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:jni/jni.dart' as jni;

--- a/lib/src/impl_jni/impl_jni.utils.dart
+++ b/lib/src/impl_jni/impl_jni.utils.dart
@@ -129,3 +129,11 @@ void _fillRandomBytes(TypedData destination) {
     }
   });
 }
+
+Future<Uint8List> _bufferStream(Stream<List<int>> data) async {
+  final builder = BytesBuilder(copy: false);
+  await for (final chunk in data) {
+    builder.add(chunk);
+  }
+  return builder.takeBytes();
+}

--- a/test/aes_ctr_counter_wrap_test.dart
+++ b/test/aes_ctr_counter_wrap_test.dart
@@ -18,7 +18,20 @@ import 'dart:typed_data';
 import 'package:test/test.dart';
 import 'package:webcrypto/webcrypto.dart';
 
+import 'src/jni_test_setup.dart'
+    if (dart.library.io) 'src/jni_test_setup_io.dart';
+
 void main() {
+  final skipReason = jniHelperSetupSkipReason;
+
+  setUpAll(() {
+    if (skipReason != null) {
+      return;
+    }
+
+    spawnJniForDesktopTests();
+  });
+
   test('AES-CTR 32-bit counter wrap does not carry into nonce', () async {
     final key = await AesCtrSecretKey.importRawKey(
       Uint8List.fromList(List<int>.generate(16, (i) => i)),
@@ -37,7 +50,7 @@ void main() {
     final ciphertextB = await key.encryptBytes(Uint8List(16), counterB, 32);
 
     expect(ciphertextA.sublist(16, 32), isNot(equals(ciphertextB)));
-  });
+  }, skip: skipReason);
 
   test('AES-CTR keeps large byte encryption length stable', () async {
     final key = await AesCtrSecretKey.importRawKey(Uint8List(16));
@@ -49,7 +62,7 @@ void main() {
 
     expect(ciphertext, hasLength(plaintext.length));
     expect(decrypted, equals(plaintext));
-  });
+  }, skip: skipReason);
 
   test('AES-CTR stream encryption matches large byte encryption', () async {
     final key = await AesCtrSecretKey.importRawKey(Uint8List(16));
@@ -62,7 +75,7 @@ void main() {
     );
 
     expect(streamedCiphertext, equals(ciphertext));
-  });
+  }, skip: skipReason);
 }
 
 Future<Uint8List> _collectBytes(Stream<List<int>> stream) async {

--- a/test/impl_jni_aesctr_test.dart
+++ b/test/impl_jni_aesctr_test.dart
@@ -1,0 +1,179 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:webcrypto/src/impl_ffi/impl_ffi.dart' as ffi_impl;
+import 'package:webcrypto/src/impl_jni/impl_jni.dart' as jni_impl;
+
+import 'src/jni_test_setup.dart'
+    if (dart.library.io) 'src/jni_test_setup_io.dart';
+
+void main() {
+  final skipReason = jniHelperSetupSkipReason;
+
+  setUpAll(() {
+    if (skipReason != null) {
+      return;
+    }
+
+    spawnJniForDesktopTests();
+  });
+
+  test('JCA AES-128-CTR encrypts and decrypts a known vector', () async {
+    final keyData = base64Decode('VPhdE6z4820SUnBmesDBSw==');
+    final plaintext = base64Decode(
+      'dXJpcyBxdWlzIG1hdHRpcyBtYXNzYS4gUGhhc2VsbHVzIGNvbnZhbGxp',
+    );
+    final counter = base64Decode('AAEECRAZJDFAUWR5kKnE4Q==');
+
+    final key = await jni_impl.webCryptImpl.aesCtrSecretKey.importRawKey(
+      keyData,
+    );
+    final ciphertext = await key.encryptBytes(plaintext, counter, 64);
+
+    final ffiKey = await ffi_impl.webCryptImpl.aesCtrSecretKey.importRawKey(
+      keyData,
+    );
+    expect(ciphertext, await ffiKey.encryptBytes(plaintext, counter, 64));
+    expect(
+      base64Encode(ciphertext),
+      'LnHSulNxQ6y+Z2rC2g8QQURwQWrI53qMPajfaef3cA0jaL+yAd3syGfz',
+    );
+    expect(await key.decryptBytes(ciphertext, counter, 64), plaintext);
+  }, skip: skipReason);
+
+  test('JCA AES-256-CTR stream encryption matches FFI', () async {
+    final keyData = base64Decode(
+      'WngeqRJDQN8vkhSxSPAM5+XQKqKZTv90uur/A5sX4Zk=',
+    );
+    final chunks = [
+      base64Decode('IG5pYmguCgpTZWQgbW9sbGlzIHNhcGllbiBpbiBncmF2aWRhIA=='),
+      base64Decode('YXVjdG9yLiBBZW5lYW4gbmliaCB0b3J0bw=='),
+    ];
+    final counter = base64Decode('/v7+/v7+/v7+/v7+/v7+/g==');
+
+    final key = await jni_impl.webCryptImpl.aesCtrSecretKey.importRawKey(
+      keyData,
+    );
+    final ciphertext = await _collectBytes(
+      key.encryptStream(Stream.fromIterable(chunks), counter, 9),
+    );
+
+    final ffiKey = await ffi_impl.webCryptImpl.aesCtrSecretKey.importRawKey(
+      keyData,
+    );
+    final ffiCiphertext = await _collectBytes(
+      ffiKey.encryptStream(Stream.fromIterable(chunks), counter, 9),
+    );
+
+    expect(ciphertext, ffiCiphertext);
+    expect(
+      base64Encode(ciphertext),
+      'Nj5naY4AWDSbh3taXM4k2Ys7gDlJJSmE4rBS2TQkYXf0DcO7G9pov5EQEXrrKk/L'
+      'jGITblQI1GkCi9ndwl4=',
+    );
+  }, skip: skipReason);
+
+  test('JCA AES-CTR counter rollover preserves the nonce bits', () async {
+    final keyData = base64Decode('mkHLvTc/F5evWm7OAMz1Ag==');
+    final plaintext = base64Decode(
+      'cwpjb21tb2RvIGF0IHNpdCBhbWV0IG1pLiBQZWxsZW50ZXNxdWUgdmVoaWN1bGEgbA==',
+    );
+    final counter = base64Decode('/v7+/v7+/v7+/v7+/v7+/g==');
+
+    final key = await jni_impl.webCryptImpl.aesCtrSecretKey.importRawKey(
+      keyData,
+    );
+    final ciphertext = await key.encryptBytes(plaintext, counter, 2);
+
+    expect(
+      base64Encode(ciphertext),
+      '74m8tH2wT2MCrtw3Qr5SUTqfOPGUGzIeRnqB8psPFu4eujcjm2VgLv+LuJubZbrdkg==',
+    );
+    expect(await key.decryptBytes(ciphertext, counter, 2), plaintext);
+  }, skip: skipReason);
+
+  test('JCA AES-CTR rejects data that would reuse a counter block', () async {
+    final key = await jni_impl.webCryptImpl.aesCtrSecretKey.importRawKey(
+      Uint8List(16),
+    );
+    final counter = Uint8List(16)..fillRange(0, 16, 0xff);
+
+    await expectLater(
+      key.encryptBytes(Uint8List(65), counter, 2),
+      throwsA(
+        isA<FormatException>().having(
+          (e) => e.message,
+          'message',
+          'input is too large for the counter length',
+        ),
+      ),
+    );
+  }, skip: skipReason);
+
+  test('JCA AES-CTR exports and imports JSON Web Keys', () async {
+    final keyData = Uint8List.fromList(List<int>.generate(16, (i) => i));
+    final key = await jni_impl.webCryptImpl.aesCtrSecretKey.importRawKey(
+      keyData,
+    );
+
+    final jwk = await key.exportJsonWebKey();
+    expect(jwk['kty'], 'oct');
+    expect(jwk['use'], 'enc');
+    expect(jwk['alg'], 'A128CTR');
+    expect(jwk['k'], 'AAECAwQFBgcICQoLDA0ODw');
+
+    final imported = await jni_impl.webCryptImpl.aesCtrSecretKey
+        .importJsonWebKey(jwk);
+    expect(await imported.exportRawKey(), keyData);
+  }, skip: skipReason);
+
+  test('JCA AES-CTR generateKey creates 128 and 256 bit keys', () async {
+    final key128 = await jni_impl.webCryptImpl.aesCtrSecretKey.generateKey(128);
+    final key256 = await jni_impl.webCryptImpl.aesCtrSecretKey.generateKey(256);
+
+    expect(await key128.exportRawKey(), hasLength(16));
+    expect(await key256.exportRawKey(), hasLength(32));
+  }, skip: skipReason);
+
+  test('JCA AES-CTR rejects invalid counter arguments', () async {
+    final key = await jni_impl.webCryptImpl.aesCtrSecretKey.importRawKey(
+      Uint8List(16),
+    );
+
+    expect(
+      () => key.encryptStream(Stream.value(Uint8List(16)), Uint8List(15), 64),
+      throwsArgumentError,
+    );
+    expect(
+      () => key.encryptStream(Stream.value(Uint8List(16)), Uint8List(16), 0),
+      throwsArgumentError,
+    );
+  }, skip: skipReason);
+}
+
+Future<Uint8List> _collectBytes(Stream<List<int>> stream) async {
+  final builder = BytesBuilder(copy: false);
+  await for (final chunk in stream) {
+    builder.add(chunk);
+  }
+  return builder.takeBytes();
+}


### PR DESCRIPTION
## Summary

Adds the JNI/JCA AES-CTR implementation on top of the existing Android JCA backend skeleton.

This PR implements:
- AES-CTR raw key import/export
- AES-CTR JWK import/export
- AES-CTR key generation using the shared AES helper
- byte and stream encryption/decryption
- JCA `Cipher("AES/CTR/NoPadding")` wiring with `IvParameterSpec`
- WebCrypto counter-length rollover handling so counter increments do not carry into nonce bits
- focused desktop JNI tests
- Android integration smoke test through the public API

## Testing

For the desktop JNI-specific test, run this once first if JNI has not been set up locally:
- `dart run jni:setup`

Verified with:
- `dart analyze`
- `dart test test/impl_jni_aesctr_test.dart`
- `dart test test/webcrypto_test.dart -p vm -n AES-CTR`
- `dart test test/aes_ctr_counter_wrap_test.dart`
- `flutter test integration_test/jni_aesctr_test.dart -d emulator-name`