### PR TITLE
Enhance documentation for EcdhPublicKey imports

### DIFF
--- a/lib/src/webcrypto/webcrypto.ecdh.dart
+++ b/lib/src/webcrypto/webcrypto.ecdh.dart
@@ -282,8 +282,30 @@ final class EcdhPublicKey {
   factory EcdhPublicKey(EcdhPublicKeyImpl impl) {
     return EcdhPublicKey._(impl);
   }
-
-  /// TODO: find out of this works on Firefox
+/// Import [EcdhPublicKey] from raw elliptic curve point.
+  ///
+  /// Creates an [EcdhPublicKey] from [keyData] given as the raw
+  /// elliptic curve point in uncompressed format. The [curve] specified
+  /// must match the curve used to generate [keyData].
+  ///
+  /// **Example**
+  /// ```dart
+  /// import 'package:webcrypto/webcrypto.dart';
+  ///
+  /// Future<void> main() async {
+  ///   // Generate a key pair.
+  ///   final keyPair = await EcdhPrivateKey.generateKey(EllipticCurve.p256);
+  ///
+  ///   // Export the public key as a raw key.
+  ///   final rawPublicKey = await keyPair.publicKey.exportRawKey();
+  ///
+  ///   // Import the raw key back as an EcdhPublicKey.
+  ///   final publicKey = await EcdhPublicKey.importRawKey(
+  ///     rawPublicKey,
+  ///     EllipticCurve.p256,
+  ///   );
+  /// }
+  /// ```
   static Future<EcdhPublicKey> importRawKey(
     List<int> keyData,
     EllipticCurve curve,
@@ -292,6 +314,33 @@ final class EcdhPublicKey {
     return EcdhPublicKey._(impl);
   }
 
+ /// Import [EcdhPublicKey] in the [SPKI][1] format.
+  ///
+  /// Creates an [EcdhPublicKey] from [keyData] given as the DER encoded
+  /// _SubjectPublicKeyInfo_ structure specified in [RFC 5280][1].
+  /// The [curve] specified must match the curve used in [keyData].
+  ///
+  /// **Example**
+  /// ```dart
+  /// import 'package:webcrypto/webcrypto.dart';
+  ///
+  /// Future<void> main() async {
+  ///   // Generate a key pair.
+  ///   final keyPair = await EcdhPrivateKey.generateKey(EllipticCurve.p256);
+  ///
+  ///   // Export the public key as SPKI.
+  ///   final spkiPublicKey = await keyPair.publicKey.exportSpkiKey();
+  ///
+  ///   // Import the SPKI key back as an EcdhPublicKey.
+  ///   final publicKey = await EcdhPublicKey.importSpkiKey(
+  ///     spkiPublicKey,
+  ///     EllipticCurve.p256,
+  ///   );
+  /// }
+  /// ```
+  ///
+  /// [1]: https://www.rfc-editor.org/rfc/rfc5280
+  ///
   /// ## Compatibility
   /// TODO: explain that Chrome can't import SPKI keys from Firefox < 72.
   ///       This is a bug in Chrome / BoringSSL (and package:webcrypto)
@@ -373,6 +422,23 @@ final class EcdhPublicKey {
     return EcdhPublicKey._(impl);
   }
 
+ /// Export the [EcdhPublicKey] as a raw elliptic curve point.
+  ///
+  /// Returns the raw elliptic curve point in uncompressed format as a
+  /// list of bytes.
+  ///
+  /// **Example**
+  /// ```dart
+  /// import 'package:webcrypto/webcrypto.dart';
+  ///
+  /// Future<void> main() async {
+  ///   // Generate a key pair.
+  ///   final keyPair = await EcdhPrivateKey.generateKey(EllipticCurve.p256);
+  ///
+  ///   // Export the public key as a raw key.
+  ///   final rawPublicKey = await keyPair.publicKey.exportRawKey();
+  /// }
+  /// ```
   Future<Uint8List> exportRawKey() => _impl.exportRawKey();
 
   /// Note: Due to bug in Chrome/BoringSSL, SPKI keys exported from Firefox < 72

--- a/lib/src/webcrypto/webcrypto.ecdh.dart
+++ b/lib/src/webcrypto/webcrypto.ecdh.dart
@@ -282,7 +282,8 @@ final class EcdhPublicKey {
   factory EcdhPublicKey(EcdhPublicKeyImpl impl) {
     return EcdhPublicKey._(impl);
   }
-/// Import [EcdhPublicKey] from raw elliptic curve point.
+  
+  /// Import [EcdhPublicKey] from raw elliptic curve point.
   ///
   /// Creates an [EcdhPublicKey] from [keyData] given as the raw
   /// elliptic curve point in uncompressed format. The [curve] specified
@@ -314,7 +315,7 @@ final class EcdhPublicKey {
     return EcdhPublicKey._(impl);
   }
 
- /// Import [EcdhPublicKey] in the [SPKI][1] format.
+  /// Import [EcdhPublicKey] in the [SPKI][1] format.
   ///
   /// Creates an [EcdhPublicKey] from [keyData] given as the DER encoded
   /// _SubjectPublicKeyInfo_ structure specified in [RFC 5280][1].
@@ -422,7 +423,7 @@ final class EcdhPublicKey {
     return EcdhPublicKey._(impl);
   }
 
- /// Export the [EcdhPublicKey] as a raw elliptic curve point.
+  /// Export the [EcdhPublicKey] as a raw elliptic curve point.
   ///
   /// Returns the raw elliptic curve point in uncompressed format as a
   /// list of bytes.

--- a/lib/src/webcrypto/webcrypto.ecdh.dart
+++ b/lib/src/webcrypto/webcrypto.ecdh.dart
@@ -281,8 +281,8 @@ final class EcdhPublicKey {
 
   factory EcdhPublicKey(EcdhPublicKeyImpl impl) {
     return EcdhPublicKey._(impl);
-  }
-  
+}
+
   /// Import [EcdhPublicKey] from raw elliptic curve point.
   ///
   /// Creates an [EcdhPublicKey] from [keyData] given as the raw

--- a/lib/src/webcrypto/webcrypto.ecdh.dart
+++ b/lib/src/webcrypto/webcrypto.ecdh.dart
@@ -281,7 +281,7 @@ final class EcdhPublicKey {
 
   factory EcdhPublicKey(EcdhPublicKeyImpl impl) {
     return EcdhPublicKey._(impl);
-}
+  }
 
   /// Import [EcdhPublicKey] from raw elliptic curve point.
   ///

--- a/lib/src/webcrypto/webcrypto.ecdh.dart
+++ b/lib/src/webcrypto/webcrypto.ecdh.dart
@@ -318,7 +318,8 @@ final class EcdhPublicKey {
   /// Import [EcdhPublicKey] in the [SPKI][1] format.
   ///
   /// Creates an [EcdhPublicKey] from [keyData] given as the DER encoded
-  /// _SubjectPublicKeyInfo_ structure specified in [RFC 5280][1].
+  /// _SubjectPublicKeyInfo_ structure specified in [RFC 5280][1], using the
+  /// EC algorithm identifiers and point encoding specified in [RFC 5480][2].
   /// The [curve] specified must match the curve used in [keyData].
   ///
   /// **Example**
@@ -341,6 +342,7 @@ final class EcdhPublicKey {
   /// ```
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc5280
+  /// [2]: https://www.rfc-editor.org/rfc/rfc5480
   ///
   /// ## Compatibility
   /// TODO: explain that Chrome can't import SPKI keys from Firefox < 72.


### PR DESCRIPTION
This PR adds missing dartdoc examples for `EcdhPublicKey` methods, as part of #283.

**Changes:**
- Added a runnable example for `importRawKey()`
- Added a runnable example for `importSpkiKey()` (existing compatibility notes preserved)
- Added documentation with example for `exportRawKey()`, which previously had no doc comment at all

All examples follow the self-contained pattern (with imports and a runnable `main()`) used elsewhere in the codebase, consistent with #281.