### PR TITLE
feat(impl_jni): add JCA RSASSA-PKCS1-v1_5 implementation

### DIFF
--- a/example/webcrypto_demo_flutter_app/README.md
+++ b/example/webcrypto_demo_flutter_app/README.md
@@ -39,3 +39,10 @@ To run the Android JNI/JCA AES-CTR smoke test:
 flutter test integration_test/jni_aesctr_test.dart \
   -d emulator-name
 ```
+
+To run the Android JNI/JCA RSASSA-PKCS1-v1_5 smoke test:
+
+```sh
+flutter test integration_test/jni_rsassapkcs1v15_test.dart \
+  -d emulator-name
+```

--- a/example/webcrypto_demo_flutter_app/integration_test/jni_rsassapkcs1v15_test.dart
+++ b/example/webcrypto_demo_flutter_app/integration_test/jni_rsassapkcs1v15_test.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webcrypto/webcrypto.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('public API RSASSA-PKCS1-v1_5 signs and verifies', (_) async {
+    final keyPair = await RsassaPkcs1V15PrivateKey.generateKey(
+      2048,
+      BigInt.from(65537),
+      Hash.sha256,
+    );
+    final privateKey = await RsassaPkcs1V15PrivateKey.importJsonWebKey(
+      await keyPair.privateKey.exportJsonWebKey(),
+      Hash.sha256,
+    );
+    final publicKey = await RsassaPkcs1V15PublicKey.importJsonWebKey(
+      await keyPair.publicKey.exportJsonWebKey(),
+      Hash.sha256,
+    );
+    final data = utf8.encode('Android JCA RSASSA-PKCS1-v1_5');
+    final signature = await privateKey.signBytes(data);
+
+    expect(await publicKey.verifyBytes(signature, data), isTrue);
+
+    final modified = Uint8List.fromList(data)..[0] ^= 0x01;
+    expect(await publicKey.verifyBytes(signature, modified), isFalse);
+  });
+}

--- a/lib/src/impl_jni/impl_jni.dart
+++ b/lib/src/impl_jni/impl_jni.dart
@@ -21,6 +21,7 @@ library;
 
 import 'dart:async';
 import 'dart:convert' show base64Url;
+import 'dart:isolate';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
@@ -44,6 +45,7 @@ part 'impl_jni.rsapss.dart';
 part 'impl_jni.rsassapkcs1v15.dart';
 part 'impl_jni.digest.dart';
 part 'impl_jni.random.dart';
+part 'impl_jni.rsa_common.dart';
 part 'impl_jni.utils.dart';
 
 const WebCryptoImpl webCryptImpl = _WebCryptoImpl();

--- a/lib/src/impl_jni/impl_jni.rsa_common.dart
+++ b/lib/src/impl_jni/impl_jni.rsa_common.dart
@@ -1,0 +1,438 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of 'impl_jni.dart';
+
+typedef _RsaKeyPairData = ({Uint8List privateKeyData, Uint8List publicKeyData});
+
+_HashImpl _rsaHashFromHash(HashImpl hash) {
+  if (hash is _HashImpl) {
+    return hash;
+  }
+  throw AssertionError('Custom implementations of HashImpl are not supported.');
+}
+
+extension _RsaHashMetadata on _HashImpl {
+  String get _rsassaPkcs1v15JcaName {
+    return switch (_jcaName) {
+      'SHA-1' => 'SHA1withRSA',
+      'SHA-256' => 'SHA256withRSA',
+      'SHA-384' => 'SHA384withRSA',
+      'SHA-512' => 'SHA512withRSA',
+      _ => throw AssertionError('Unknown hash algorithm: $_jcaName'),
+    };
+  }
+
+  String get _rsassaPkcs1v15JwkAlg {
+    return switch (_jcaName) {
+      'SHA-1' => 'RS1',
+      'SHA-256' => 'RS256',
+      'SHA-384' => 'RS384',
+      'SHA-512' => 'RS512',
+      _ => throw AssertionError('Unknown hash algorithm: $_jcaName'),
+    };
+  }
+}
+
+Uint8List _importPkcs8RsaPrivateKey(Uint8List keyData) {
+  try {
+    return jni.using((arena) {
+      final key = _rsaPrivateKeyFromPkcs8(arena, keyData);
+      return _copyEncodedRsaKey(arena, key, 'private');
+    });
+  } on jni.JThrowable catch (e) {
+    throw _rsaKeyFormatException(e, 'Unable to import PKCS#8 RSA private key');
+  }
+}
+
+Uint8List _importSpkiRsaPublicKey(Uint8List keyData) {
+  try {
+    return jni.using((arena) {
+      final key = _rsaPublicKeyFromSpki(arena, keyData);
+      return _copyEncodedRsaKey(arena, key, 'public');
+    });
+  } on jni.JThrowable catch (e) {
+    throw _rsaKeyFormatException(e, 'Unable to import SPKI RSA public key');
+  }
+}
+
+Uint8List _importJwkRsaPrivateKey(
+  Map<String, dynamic> jwkData, {
+  required String expectedAlg,
+  required String expectedUse,
+}) {
+  final jwk = JsonWebKey.fromJson(jwkData);
+  _validateRsaJwk(jwk, expectedAlg: expectedAlg, expectedUse: expectedUse);
+
+  final n = _readRsaJwkInteger(jwk.n, 'n');
+  final e = _readRsaJwkInteger(jwk.e, 'e');
+  final d = _readRsaJwkInteger(jwk.d, 'd');
+  final p = _readRsaJwkInteger(jwk.p, 'p');
+  final q = _readRsaJwkInteger(jwk.q, 'q');
+  final dp = _readRsaJwkInteger(jwk.dp, 'dp');
+  final dq = _readRsaJwkInteger(jwk.dq, 'dq');
+  final qi = _readRsaJwkInteger(jwk.qi, 'qi');
+
+  try {
+    return jni.using((arena) {
+      final keyFactory = _rsaKeyFactory(arena);
+      final keySpec = RSAPrivateCrtKeySpec(
+        _rsaBigInteger(arena, n),
+        _rsaBigInteger(arena, e),
+        _rsaBigInteger(arena, d),
+        _rsaBigInteger(arena, p),
+        _rsaBigInteger(arena, q),
+        _rsaBigInteger(arena, dp),
+        _rsaBigInteger(arena, dq),
+        _rsaBigInteger(arena, qi),
+      )..releasedBy(arena);
+      final key = keyFactory.generatePrivate(keySpec);
+      if (key == null) {
+        throw AssertionError('JCA RSA KeyFactory returned a null private key');
+      }
+      key.releasedBy(arena);
+      return _copyEncodedRsaKey(arena, key, 'private');
+    });
+  } on jni.JThrowable catch (e) {
+    throw _rsaKeyFormatException(e, 'Unable to import RSA private JWK');
+  }
+}
+
+Uint8List _importJwkRsaPublicKey(
+  Map<String, dynamic> jwkData, {
+  required String expectedAlg,
+  required String expectedUse,
+}) {
+  final jwk = JsonWebKey.fromJson(jwkData);
+  _validateRsaJwk(jwk, expectedAlg: expectedAlg, expectedUse: expectedUse);
+
+  final n = _readRsaJwkInteger(jwk.n, 'n');
+  final e = _readRsaJwkInteger(jwk.e, 'e');
+
+  try {
+    return jni.using((arena) {
+      final keyFactory = _rsaKeyFactory(arena);
+      final keySpec = RSAPublicKeySpec(
+        _rsaBigInteger(arena, n),
+        _rsaBigInteger(arena, e),
+      )..releasedBy(arena);
+      final key = keyFactory.generatePublic(keySpec);
+      if (key == null) {
+        throw AssertionError('JCA RSA KeyFactory returned a null public key');
+      }
+      key.releasedBy(arena);
+      return _copyEncodedRsaKey(arena, key, 'public');
+    });
+  } on jni.JThrowable catch (e) {
+    throw _rsaKeyFormatException(e, 'Unable to import RSA public JWK');
+  }
+}
+
+Map<String, dynamic> _exportJwkRsaPrivateKey(
+  Uint8List keyData, {
+  required String jwkAlg,
+  required String jwkUse,
+}) {
+  try {
+    return jni.using((arena) {
+      final key = _rsaPrivateKeyFromPkcs8(arena, keyData);
+      if (!key.isA(RSAPrivateCrtKey.type)) {
+        throw UnsupportedError(
+          'The JCA provider does not expose RSA CRT parameters for JWK export',
+        );
+      }
+      final rsaKey = key.as(RSAPrivateCrtKey.type)..releasedBy(arena);
+
+      return JsonWebKey(
+        kty: 'RSA',
+        use: jwkUse,
+        alg: jwkAlg,
+        n: _encodeRsaBigInteger(arena, rsaKey.getModulus(), 'modulus'),
+        e: _encodeRsaBigInteger(
+          arena,
+          rsaKey.getPublicExponent(),
+          'public exponent',
+        ),
+        d: _encodeRsaBigInteger(
+          arena,
+          rsaKey.getPrivateExponent(),
+          'private exponent',
+        ),
+        p: _encodeRsaBigInteger(arena, rsaKey.getPrimeP(), 'prime P'),
+        q: _encodeRsaBigInteger(arena, rsaKey.getPrimeQ(), 'prime Q'),
+        dp: _encodeRsaBigInteger(
+          arena,
+          rsaKey.getPrimeExponentP(),
+          'prime exponent P',
+        ),
+        dq: _encodeRsaBigInteger(
+          arena,
+          rsaKey.getPrimeExponentQ(),
+          'prime exponent Q',
+        ),
+        qi: _encodeRsaBigInteger(
+          arena,
+          rsaKey.getCrtCoefficient(),
+          'CRT coefficient',
+        ),
+      ).toJson();
+    });
+  } on jni.JThrowable catch (e) {
+    throw _rsaOperationError(e, 'Unable to export RSA private JWK');
+  }
+}
+
+Map<String, dynamic> _exportJwkRsaPublicKey(
+  Uint8List keyData, {
+  required String jwkAlg,
+  required String jwkUse,
+}) {
+  try {
+    return jni.using((arena) {
+      final key = _rsaPublicKeyFromSpki(arena, keyData);
+      if (!key.isA(RSAPublicKey.type)) {
+        throw AssertionError(
+          'JCA RSA KeyFactory returned a non-RSA public key',
+        );
+      }
+      final rsaKey = key.as(RSAPublicKey.type)..releasedBy(arena);
+
+      return JsonWebKey(
+        kty: 'RSA',
+        use: jwkUse,
+        alg: jwkAlg,
+        n: _encodeRsaBigInteger(arena, rsaKey.getModulus(), 'modulus'),
+        e: _encodeRsaBigInteger(
+          arena,
+          rsaKey.getPublicExponent(),
+          'public exponent',
+        ),
+      ).toJson();
+    });
+  } on jni.JThrowable catch (e) {
+    throw _rsaOperationError(e, 'Unable to export RSA public JWK');
+  }
+}
+
+Future<_RsaKeyPairData> _generateRsaKeyPair(
+  int modulusLength,
+  BigInt publicExponent,
+) async {
+  _validateRsaKeyGenerationParameters(modulusLength, publicExponent);
+  return Isolate.run(
+    () => _generateRsaKeyPairOnCurrentIsolate(modulusLength, publicExponent),
+    debugName: 'JCA RSA key generation',
+  );
+}
+
+_RsaKeyPairData _generateRsaKeyPairOnCurrentIsolate(
+  int modulusLength,
+  BigInt publicExponent,
+) {
+  try {
+    return jni.using((arena) {
+      final algorithm = 'RSA'.toJString()..releasedBy(arena);
+      final generator = KeyPairGenerator.getInstance(algorithm);
+      if (generator == null) {
+        throw AssertionError('JCA RSA KeyPairGenerator returned null');
+      }
+      generator.releasedBy(arena);
+
+      final exponent = _rsaBigInteger(
+        arena,
+        _unsignedBytesFromBigInt(publicExponent),
+      );
+      final parameters = RSAKeyGenParameterSpec(modulusLength, exponent)
+        ..releasedBy(arena);
+      generator.initialize$2(parameters);
+
+      final pair = generator.generateKeyPair();
+      if (pair == null) {
+        throw AssertionError('JCA RSA KeyPairGenerator returned null key pair');
+      }
+      pair.releasedBy(arena);
+
+      final privateKey = pair.private;
+      final publicKey = pair.public;
+      if (privateKey == null || publicKey == null) {
+        throw AssertionError('JCA RSA key pair contains a null key');
+      }
+      privateKey.releasedBy(arena);
+      publicKey.releasedBy(arena);
+
+      return (
+        privateKeyData: _copyEncodedRsaKey(arena, privateKey, 'private'),
+        publicKeyData: _copyEncodedRsaKey(arena, publicKey, 'public'),
+      );
+    });
+  } on jni.JThrowable catch (e) {
+    throw _rsaOperationError(e, 'JCA RSA key generation failed');
+  }
+}
+
+jni.JObject _rsaPrivateKeyFromPkcs8(jni.Arena arena, Uint8List keyData) {
+  final keyFactory = _rsaKeyFactory(arena);
+  final encoded = arena.copyToJByteArray(keyData);
+  final keySpec = PKCS8EncodedKeySpec(encoded)..releasedBy(arena);
+  final key = keyFactory.generatePrivate(keySpec);
+  if (key == null) {
+    throw AssertionError('JCA RSA KeyFactory returned a null private key');
+  }
+  key.releasedBy(arena);
+  return key;
+}
+
+jni.JObject _rsaPublicKeyFromSpki(jni.Arena arena, Uint8List keyData) {
+  final keyFactory = _rsaKeyFactory(arena);
+  final encoded = arena.copyToJByteArray(keyData);
+  final keySpec = X509EncodedKeySpec(encoded)..releasedBy(arena);
+  final key = keyFactory.generatePublic(keySpec);
+  if (key == null) {
+    throw AssertionError('JCA RSA KeyFactory returned a null public key');
+  }
+  key.releasedBy(arena);
+  return key;
+}
+
+KeyFactory _rsaKeyFactory(jni.Arena arena) {
+  final algorithm = 'RSA'.toJString()..releasedBy(arena);
+  final keyFactory = KeyFactory.getInstance(algorithm);
+  if (keyFactory == null) {
+    throw AssertionError('JCA RSA KeyFactory returned null');
+  }
+  keyFactory.releasedBy(arena);
+  return keyFactory;
+}
+
+Uint8List _copyEncodedRsaKey(jni.Arena arena, jni.JObject key, String keyType) {
+  final jcaKey = key.as(Key.type)..releasedBy(arena);
+  final encoded = jcaKey.getEncoded();
+  if (encoded == null) {
+    throw AssertionError('JCA RSA $keyType key has no encoded form');
+  }
+  encoded.releasedBy(arena);
+  return encoded.copyToDartBytes();
+}
+
+BigInteger _rsaBigInteger(jni.Arena arena, Uint8List unsignedBytes) {
+  final bytes = arena.copyToJByteArray(unsignedBytes);
+  return BigInteger.new$3(1, bytes)..releasedBy(arena);
+}
+
+String _encodeRsaBigInteger(jni.Arena arena, BigInteger? value, String name) {
+  if (value == null) {
+    throw AssertionError('JCA RSA key has no $name');
+  }
+  value.releasedBy(arena);
+  final encoded = value.toByteArray();
+  if (encoded == null) {
+    throw AssertionError(
+      'JCA BigInteger.toByteArray() returned null for $name',
+    );
+  }
+  encoded.releasedBy(arena);
+  final signedBytes = encoded.copyToDartBytes();
+  final unsignedBytes = signedBytes.length > 1 && signedBytes.first == 0
+      ? Uint8List.sublistView(signedBytes, 1)
+      : signedBytes;
+  return _jwkEncodeBase64UrlNoPadding(unsignedBytes);
+}
+
+void _validateRsaJwk(
+  JsonWebKey jwk, {
+  required String expectedAlg,
+  required String expectedUse,
+}) {
+  void check(bool condition, String prop, String message) {
+    _checkData(condition, 'JWK property "$prop" $message');
+  }
+
+  check(jwk.kty == 'RSA', 'kty', 'must be "RSA"');
+  check(
+    jwk.alg == null || jwk.alg == expectedAlg,
+    'alg',
+    'must be "$expectedAlg", if present',
+  );
+  check(
+    jwk.use == null || jwk.use == expectedUse,
+    'use',
+    'must be "$expectedUse", if present',
+  );
+}
+
+Uint8List _readRsaJwkInteger(String? value, String prop) {
+  _checkData(value != null, 'JWK property "$prop" must be present');
+  final bytes = _jwkDecodeBase64UrlNoPadding(value!, prop);
+  _checkData(bytes.isNotEmpty, 'JWK property "$prop" must not be empty');
+  _checkData(
+    bytes.length == 1 || bytes.first != 0,
+    'JWK property "$prop" must not have leading zeros',
+  );
+  return bytes;
+}
+
+Uint8List _unsignedBytesFromBigInt(BigInt value) {
+  if (value <= BigInt.zero) {
+    throw ArgumentError.value(value, 'value', 'must be positive');
+  }
+  final bytes = <int>[];
+  var remaining = value;
+  while (remaining > BigInt.zero) {
+    bytes.add((remaining & BigInt.from(0xff)).toInt());
+    remaining >>= 8;
+  }
+  return Uint8List.fromList(bytes.reversed.toList());
+}
+
+void _validateRsaKeyGenerationParameters(
+  int modulusLength,
+  BigInt publicExponent,
+) {
+  if (modulusLength < 256 || modulusLength > 16384) {
+    throw UnsupportedError(
+      'modulusLength must be between 256 and 16384 bits; '
+      '$modulusLength is not supported',
+    );
+  }
+  if (modulusLength % 8 != 0) {
+    throw UnsupportedError('modulusLength must be a multiple of 8');
+  }
+  if (publicExponent != BigInt.from(3) &&
+      publicExponent != BigInt.from(65537)) {
+    throw UnsupportedError('publicExponent is not supported; use 3 or 65537');
+  }
+}
+
+FormatException _rsaKeyFormatException(
+  jni.JThrowable throwable,
+  String context,
+) {
+  final message = _rsaThrowableMessage(throwable);
+  return FormatException('$context: $message');
+}
+
+OperationError _rsaOperationError(jni.JThrowable throwable, String context) {
+  final message = _rsaThrowableMessage(throwable);
+  return operationError('$context: $message');
+}
+
+String _rsaThrowableMessage(jni.JThrowable throwable) {
+  late final String message;
+  try {
+    message = throwable.message;
+  } finally {
+    throwable.release();
+  }
+  return message;
+}

--- a/lib/src/impl_jni/impl_jni.rsa_common.dart
+++ b/lib/src/impl_jni/impl_jni.rsa_common.dart
@@ -52,31 +52,35 @@ extension _RsaHashMetadata on _HashImpl {
   }
 }
 
-Uint8List _importPkcs8RsaPrivateKey(Uint8List keyData) {
+jni.JObject _importPkcs8RsaPrivateKey(Uint8List keyData) {
   _validateRsaDerEncoding(keyData, 'PKCS#8 RSA private key');
   try {
     return jni.using((arena) {
-      final key = _rsaPrivateKeyFromPkcs8(arena, keyData, validate: true);
-      return _copyEncodedRsaKey(arena, key, 'private');
+      final key = _rsaPrivateKeyFromPkcs8(arena, keyData);
+      return _validateRsaKeyBeforeOwnershipTransfer(key, () {
+        _validateRsaPrivateKey(arena, key);
+      });
     });
   } on jni.JThrowable catch (e) {
     throw _rsaKeyFormatException(e, 'Unable to import PKCS#8 RSA private key');
   }
 }
 
-Uint8List _importSpkiRsaPublicKey(Uint8List keyData) {
+jni.JObject _importSpkiRsaPublicKey(Uint8List keyData) {
   _validateRsaDerEncoding(keyData, 'SPKI RSA public key');
   try {
     return jni.using((arena) {
-      final key = _rsaPublicKeyFromSpki(arena, keyData, validate: true);
-      return _copyEncodedRsaKey(arena, key, 'public');
+      final key = _rsaPublicKeyFromSpki(arena, keyData);
+      return _validateRsaKeyBeforeOwnershipTransfer(key, () {
+        _validateRsaPublicKey(arena, key);
+      });
     });
   } on jni.JThrowable catch (e) {
     throw _rsaKeyFormatException(e, 'Unable to import SPKI RSA public key');
   }
 }
 
-Uint8List _importJwkRsaPrivateKey(
+jni.JObject _importJwkRsaPrivateKey(
   Map<String, dynamic> jwkData, {
   required String expectedAlg,
   required String expectedUse,
@@ -110,16 +114,16 @@ Uint8List _importJwkRsaPrivateKey(
       if (key == null) {
         throw AssertionError('JCA RSA KeyFactory returned a null private key');
       }
-      key.releasedBy(arena);
-      _validateRsaPrivateKey(arena, key);
-      return _copyEncodedRsaKey(arena, key, 'private');
+      return _validateRsaKeyBeforeOwnershipTransfer(key, () {
+        _validateRsaPrivateKey(arena, key);
+      });
     });
   } on jni.JThrowable catch (e) {
     throw _rsaKeyFormatException(e, 'Unable to import RSA private JWK');
   }
 }
 
-Uint8List _importJwkRsaPublicKey(
+jni.JObject _importJwkRsaPublicKey(
   Map<String, dynamic> jwkData, {
   required String expectedAlg,
   required String expectedUse,
@@ -141,23 +145,44 @@ Uint8List _importJwkRsaPublicKey(
       if (key == null) {
         throw AssertionError('JCA RSA KeyFactory returned a null public key');
       }
-      key.releasedBy(arena);
-      _validateRsaPublicKey(arena, key);
-      return _copyEncodedRsaKey(arena, key, 'public');
+      return _validateRsaKeyBeforeOwnershipTransfer(key, () {
+        _validateRsaPublicKey(arena, key);
+      });
     });
   } on jni.JThrowable catch (e) {
     throw _rsaKeyFormatException(e, 'Unable to import RSA public JWK');
   }
 }
 
+jni.JObject _validateRsaKeyBeforeOwnershipTransfer(
+  jni.JObject key,
+  void Function() validate,
+) {
+  try {
+    validate();
+    return key;
+  } catch (_) {
+    // The key is not persistent until ownership transfers to a Dart wrapper.
+    key.release();
+    rethrow;
+  }
+}
+
+Uint8List _exportEncodedRsaKey(jni.JObject key, String keyType) {
+  try {
+    return jni.using((arena) => _copyEncodedRsaKey(arena, key, keyType));
+  } on jni.JThrowable catch (e) {
+    throw _rsaOperationError(e, 'Unable to export RSA $keyType key');
+  }
+}
+
 Map<String, dynamic> _exportJwkRsaPrivateKey(
-  Uint8List keyData, {
+  jni.JObject key, {
   required String jwkAlg,
   required String jwkUse,
 }) {
   try {
     return jni.using((arena) {
-      final key = _rsaPrivateKeyFromPkcs8(arena, keyData);
       if (!key.isA(RSAPrivateCrtKey.type)) {
         throw UnsupportedError(
           'The JCA provider does not expose RSA CRT parameters for JWK export',
@@ -205,13 +230,12 @@ Map<String, dynamic> _exportJwkRsaPrivateKey(
 }
 
 Map<String, dynamic> _exportJwkRsaPublicKey(
-  Uint8List keyData, {
+  jni.JObject key, {
   required String jwkAlg,
   required String jwkUse,
 }) {
   try {
     return jni.using((arena) {
-      final key = _rsaPublicKeyFromSpki(arena, keyData);
       if (!key.isA(RSAPublicKey.type)) {
         throw AssertionError(
           'JCA RSA KeyFactory returned a non-RSA public key',
@@ -292,11 +316,7 @@ _RsaKeyPairData _generateRsaKeyPairOnCurrentIsolate(
   }
 }
 
-jni.JObject _rsaPrivateKeyFromPkcs8(
-  jni.Arena arena,
-  Uint8List keyData, {
-  bool validate = false,
-}) {
+jni.JObject _rsaPrivateKeyFromPkcs8(jni.Arena arena, Uint8List keyData) {
   final keyFactory = _rsaKeyFactory(arena);
   final encoded = arena.copyToJByteArray(keyData);
   final keySpec = PKCS8EncodedKeySpec(encoded)..releasedBy(arena);
@@ -304,18 +324,12 @@ jni.JObject _rsaPrivateKeyFromPkcs8(
   if (key == null) {
     throw AssertionError('JCA RSA KeyFactory returned a null private key');
   }
-  key.releasedBy(arena);
-  if (validate) {
-    _validateRsaPrivateKey(arena, key);
-  }
+  // Ownership transfers to the Dart key wrapper, so this reference must not
+  // be registered with the temporary arena.
   return key;
 }
 
-jni.JObject _rsaPublicKeyFromSpki(
-  jni.Arena arena,
-  Uint8List keyData, {
-  bool validate = false,
-}) {
+jni.JObject _rsaPublicKeyFromSpki(jni.Arena arena, Uint8List keyData) {
   final keyFactory = _rsaKeyFactory(arena);
   final encoded = arena.copyToJByteArray(keyData);
   final keySpec = X509EncodedKeySpec(encoded)..releasedBy(arena);
@@ -323,10 +337,8 @@ jni.JObject _rsaPublicKeyFromSpki(
   if (key == null) {
     throw AssertionError('JCA RSA KeyFactory returned a null public key');
   }
-  key.releasedBy(arena);
-  if (validate) {
-    _validateRsaPublicKey(arena, key);
-  }
+  // Ownership transfers to the Dart key wrapper, so this reference must not
+  // be registered with the temporary arena.
   return key;
 }
 

--- a/lib/src/impl_jni/impl_jni.rsa_common.dart
+++ b/lib/src/impl_jni/impl_jni.rsa_common.dart
@@ -52,7 +52,7 @@ extension _RsaHashMetadata on _HashImpl {
   }
 }
 
-jni.JObject _importPkcs8RsaPrivateKey(Uint8List keyData) {
+_JcaKeyOwner _importPkcs8RsaPrivateKey(Uint8List keyData) {
   _validateRsaDerEncoding(keyData, 'PKCS#8 RSA private key');
   try {
     return jni.using((arena) {
@@ -66,7 +66,7 @@ jni.JObject _importPkcs8RsaPrivateKey(Uint8List keyData) {
   }
 }
 
-jni.JObject _importSpkiRsaPublicKey(Uint8List keyData) {
+_JcaKeyOwner _importSpkiRsaPublicKey(Uint8List keyData) {
   _validateRsaDerEncoding(keyData, 'SPKI RSA public key');
   try {
     return jni.using((arena) {
@@ -80,7 +80,7 @@ jni.JObject _importSpkiRsaPublicKey(Uint8List keyData) {
   }
 }
 
-jni.JObject _importJwkRsaPrivateKey(
+_JcaKeyOwner _importJwkRsaPrivateKey(
   Map<String, dynamic> jwkData, {
   required String expectedAlg,
   required String expectedUse,
@@ -123,7 +123,7 @@ jni.JObject _importJwkRsaPrivateKey(
   }
 }
 
-jni.JObject _importJwkRsaPublicKey(
+_JcaKeyOwner _importJwkRsaPublicKey(
   Map<String, dynamic> jwkData, {
   required String expectedAlg,
   required String expectedUse,
@@ -154,13 +154,13 @@ jni.JObject _importJwkRsaPublicKey(
   }
 }
 
-jni.JObject _validateRsaKeyBeforeOwnershipTransfer(
+_JcaKeyOwner _validateRsaKeyBeforeOwnershipTransfer(
   jni.JObject key,
   void Function() validate,
 ) {
   try {
     validate();
-    return key;
+    return _JcaKeyOwner(key);
   } catch (_) {
     // The key is not persistent until ownership transfers to a Dart wrapper.
     key.release();
@@ -168,21 +168,22 @@ jni.JObject _validateRsaKeyBeforeOwnershipTransfer(
   }
 }
 
-Uint8List _exportEncodedRsaKey(jni.JObject key, String keyType) {
+Uint8List _exportEncodedRsaKey(_JcaKeyOwner owner, String keyType) {
   try {
-    return jni.using((arena) => _copyEncodedRsaKey(arena, key, keyType));
+    return jni.using((arena) => _copyEncodedRsaKey(arena, owner.key, keyType));
   } on jni.JThrowable catch (e) {
     throw _rsaOperationError(e, 'Unable to export RSA $keyType key');
   }
 }
 
 Map<String, dynamic> _exportJwkRsaPrivateKey(
-  jni.JObject key, {
+  _JcaKeyOwner owner, {
   required String jwkAlg,
   required String jwkUse,
 }) {
   try {
     return jni.using((arena) {
+      final key = owner.key;
       if (!key.isA(RSAPrivateCrtKey.type)) {
         throw UnsupportedError(
           'The JCA provider does not expose RSA CRT parameters for JWK export',
@@ -230,12 +231,13 @@ Map<String, dynamic> _exportJwkRsaPrivateKey(
 }
 
 Map<String, dynamic> _exportJwkRsaPublicKey(
-  jni.JObject key, {
+  _JcaKeyOwner owner, {
   required String jwkAlg,
   required String jwkUse,
 }) {
   try {
     return jni.using((arena) {
+      final key = owner.key;
       if (!key.isA(RSAPublicKey.type)) {
         throw AssertionError(
           'JCA RSA KeyFactory returned a non-RSA public key',

--- a/lib/src/impl_jni/impl_jni.rsa_common.dart
+++ b/lib/src/impl_jni/impl_jni.rsa_common.dart
@@ -16,6 +16,13 @@ part of 'impl_jni.dart';
 
 typedef _RsaKeyPairData = ({Uint8List privateKeyData, Uint8List publicKeyData});
 
+// Keep imported-key limits aligned with rsa_check_public_key(), which backs
+// the FFI implementation's RSA_check_key() validation. See:
+// third_party/boringssl/src/crypto/fipsmodule/rsa/rsa_impl.cc.inc
+const _rsaMinModulusBits = 512;
+const _rsaMaxModulusBits = 16384;
+const _rsaMaxPublicExponentBits = 33;
+
 _HashImpl _rsaHashFromHash(HashImpl hash) {
   if (hash is _HashImpl) {
     return hash;
@@ -46,9 +53,10 @@ extension _RsaHashMetadata on _HashImpl {
 }
 
 Uint8List _importPkcs8RsaPrivateKey(Uint8List keyData) {
+  _validateRsaDerEncoding(keyData, 'PKCS#8 RSA private key');
   try {
     return jni.using((arena) {
-      final key = _rsaPrivateKeyFromPkcs8(arena, keyData);
+      final key = _rsaPrivateKeyFromPkcs8(arena, keyData, validate: true);
       return _copyEncodedRsaKey(arena, key, 'private');
     });
   } on jni.JThrowable catch (e) {
@@ -57,9 +65,10 @@ Uint8List _importPkcs8RsaPrivateKey(Uint8List keyData) {
 }
 
 Uint8List _importSpkiRsaPublicKey(Uint8List keyData) {
+  _validateRsaDerEncoding(keyData, 'SPKI RSA public key');
   try {
     return jni.using((arena) {
-      final key = _rsaPublicKeyFromSpki(arena, keyData);
+      final key = _rsaPublicKeyFromSpki(arena, keyData, validate: true);
       return _copyEncodedRsaKey(arena, key, 'public');
     });
   } on jni.JThrowable catch (e) {
@@ -102,6 +111,7 @@ Uint8List _importJwkRsaPrivateKey(
         throw AssertionError('JCA RSA KeyFactory returned a null private key');
       }
       key.releasedBy(arena);
+      _validateRsaPrivateKey(arena, key);
       return _copyEncodedRsaKey(arena, key, 'private');
     });
   } on jni.JThrowable catch (e) {
@@ -132,6 +142,7 @@ Uint8List _importJwkRsaPublicKey(
         throw AssertionError('JCA RSA KeyFactory returned a null public key');
       }
       key.releasedBy(arena);
+      _validateRsaPublicKey(arena, key);
       return _copyEncodedRsaKey(arena, key, 'public');
     });
   } on jni.JThrowable catch (e) {
@@ -281,7 +292,11 @@ _RsaKeyPairData _generateRsaKeyPairOnCurrentIsolate(
   }
 }
 
-jni.JObject _rsaPrivateKeyFromPkcs8(jni.Arena arena, Uint8List keyData) {
+jni.JObject _rsaPrivateKeyFromPkcs8(
+  jni.Arena arena,
+  Uint8List keyData, {
+  bool validate = false,
+}) {
   final keyFactory = _rsaKeyFactory(arena);
   final encoded = arena.copyToJByteArray(keyData);
   final keySpec = PKCS8EncodedKeySpec(encoded)..releasedBy(arena);
@@ -290,10 +305,17 @@ jni.JObject _rsaPrivateKeyFromPkcs8(jni.Arena arena, Uint8List keyData) {
     throw AssertionError('JCA RSA KeyFactory returned a null private key');
   }
   key.releasedBy(arena);
+  if (validate) {
+    _validateRsaPrivateKey(arena, key);
+  }
   return key;
 }
 
-jni.JObject _rsaPublicKeyFromSpki(jni.Arena arena, Uint8List keyData) {
+jni.JObject _rsaPublicKeyFromSpki(
+  jni.Arena arena,
+  Uint8List keyData, {
+  bool validate = false,
+}) {
   final keyFactory = _rsaKeyFactory(arena);
   final encoded = arena.copyToJByteArray(keyData);
   final keySpec = X509EncodedKeySpec(encoded)..releasedBy(arena);
@@ -302,6 +324,9 @@ jni.JObject _rsaPublicKeyFromSpki(jni.Arena arena, Uint8List keyData) {
     throw AssertionError('JCA RSA KeyFactory returned a null public key');
   }
   key.releasedBy(arena);
+  if (validate) {
+    _validateRsaPublicKey(arena, key);
+  }
   return key;
 }
 
@@ -330,11 +355,83 @@ BigInteger _rsaBigInteger(jni.Arena arena, Uint8List unsignedBytes) {
   return BigInteger.new$3(1, bytes)..releasedBy(arena);
 }
 
-String _encodeRsaBigInteger(jni.Arena arena, BigInteger? value, String name) {
-  if (value == null) {
-    throw AssertionError('JCA RSA key has no $name');
+void _validateRsaPrivateKey(jni.Arena arena, jni.JObject key) {
+  // JCA KeyFactory constructs provider key objects but can defer CRT
+  // consistency checks until the first private-key operation. Validate during
+  // import so malformed keys fail with the public API's FormatException
+  // instead of a later OperationError.
+  _checkData(
+    key.isA(RSAPrivateCrtKey.type),
+    'Invalid RSA private key: CRT parameters are required',
+  );
+  final rsaKey = key.as(RSAPrivateCrtKey.type)..releasedBy(arena);
+
+  _validateRsaPrivateComponents(
+    n: _readPositiveRsaBigInteger(arena, rsaKey.getModulus(), 'n'),
+    e: _readPositiveRsaBigInteger(arena, rsaKey.getPublicExponent(), 'e'),
+    d: _readPositiveRsaBigInteger(arena, rsaKey.getPrivateExponent(), 'd'),
+    p: _readPositiveRsaBigInteger(
+      arena,
+      rsaKey.getPrimeP(),
+      'p',
+      mustBePrime: true,
+    ),
+    q: _readPositiveRsaBigInteger(
+      arena,
+      rsaKey.getPrimeQ(),
+      'q',
+      mustBePrime: true,
+    ),
+    dp: _readPositiveRsaBigInteger(arena, rsaKey.getPrimeExponentP(), 'dp'),
+    dq: _readPositiveRsaBigInteger(arena, rsaKey.getPrimeExponentQ(), 'dq'),
+    qi: _readPositiveRsaBigInteger(arena, rsaKey.getCrtCoefficient(), 'qi'),
+  );
+}
+
+void _validateRsaPublicKey(jni.Arena arena, jni.JObject key) {
+  _checkData(
+    key.isA(RSAPublicKey.type),
+    'Invalid RSA public key: RSA parameters are required',
+  );
+  final rsaKey = key.as(RSAPublicKey.type)..releasedBy(arena);
+  _validateRsaPublicComponents(
+    n: _readPositiveRsaBigInteger(arena, rsaKey.getModulus(), 'n'),
+    e: _readPositiveRsaBigInteger(arena, rsaKey.getPublicExponent(), 'e'),
+  );
+}
+
+BigInt _readPositiveRsaBigInteger(
+  jni.Arena arena,
+  BigInteger? value,
+  String name, {
+  bool mustBePrime = false,
+}) {
+  _checkData(value != null, 'Invalid RSA key: $name is missing');
+  value!.releasedBy(arena);
+  _checkData(value.signum() > 0, 'Invalid RSA key: $name must be positive');
+  if (mustBePrime) {
+    // BigInteger specifies a false-positive probability of at most
+    // 2^-certainty for isProbablePrime().
+    // https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/math/BigInteger.html#isProbablePrime(int)
+    _checkData(
+      value.isProbablePrime(100),
+      'Invalid RSA private key: $name is not prime',
+    );
   }
-  value.releasedBy(arena);
+
+  final bytes = _copyUnsignedRsaBigInteger(arena, value, name);
+  var result = BigInt.zero;
+  for (final byte in bytes) {
+    result = (result << 8) | BigInt.from(byte);
+  }
+  return result;
+}
+
+Uint8List _copyUnsignedRsaBigInteger(
+  jni.Arena arena,
+  BigInteger value,
+  String name,
+) {
   final encoded = value.toByteArray();
   if (encoded == null) {
     throw AssertionError(
@@ -343,10 +440,70 @@ String _encodeRsaBigInteger(jni.Arena arena, BigInteger? value, String name) {
   }
   encoded.releasedBy(arena);
   final signedBytes = encoded.copyToDartBytes();
-  final unsignedBytes = signedBytes.length > 1 && signedBytes.first == 0
-      ? Uint8List.sublistView(signedBytes, 1)
-      : signedBytes;
-  return _jwkEncodeBase64UrlNoPadding(unsignedBytes);
+  final start = signedBytes.length > 1 && signedBytes.first == 0 ? 1 : 0;
+  return Uint8List.sublistView(signedBytes, start);
+}
+
+void _validateRsaPrivateComponents({
+  required BigInt n,
+  required BigInt e,
+  required BigInt d,
+  required BigInt p,
+  required BigInt q,
+  required BigInt dp,
+  required BigInt dq,
+  required BigInt qi,
+}) {
+  // Validate the two-prime RSA relationships from PKCS #1. The corresponding
+  // JWK fields are defined by JSON Web Algorithms:
+  // https://www.rfc-editor.org/rfc/rfc8017#section-3.2
+  // https://www.rfc-editor.org/rfc/rfc7518#section-6.3.2.2
+  // The FFI backend checks the same relationships with RSA_check_key(); see:
+  // third_party/boringssl/src/crypto/fipsmodule/rsa/rsa.cc.inc
+  final one = BigInt.one;
+  _validateRsaPublicComponents(n: n, e: e);
+  _checkData(p != q, 'Invalid RSA private key: p and q must differ');
+  _checkData(
+    p.isOdd && q.isOdd,
+    'Invalid RSA private key: p and q must be odd',
+  );
+  _checkData(n == p * q, 'Invalid RSA private key: n does not equal p * q');
+  _checkData(d > one && d < n, 'Invalid RSA private key: invalid d');
+
+  final pMinusOne = p - one;
+  final qMinusOne = q - one;
+  final lambda = (pMinusOne ~/ pMinusOne.gcd(qMinusOne)) * qMinusOne;
+  _checkData(
+    (d * e) % lambda == one,
+    'Invalid RSA private key: d and e are inconsistent',
+  );
+  _checkData(dp == d % pMinusOne, 'Invalid RSA private key: invalid dp');
+  _checkData(dq == d % qMinusOne, 'Invalid RSA private key: invalid dq');
+  _checkData(qi == q.modInverse(p), 'Invalid RSA private key: invalid qi');
+}
+
+void _validateRsaPublicComponents({required BigInt n, required BigInt e}) {
+  final one = BigInt.one;
+  _checkData(
+    n.bitLength >= _rsaMinModulusBits &&
+        n.bitLength <= _rsaMaxModulusBits &&
+        n.isOdd,
+    'Invalid RSA public key: invalid n',
+  );
+  _checkData(
+    e > one && e.isOdd && e.bitLength <= _rsaMaxPublicExponentBits && e < n,
+    'Invalid RSA public key: invalid e',
+  );
+}
+
+String _encodeRsaBigInteger(jni.Arena arena, BigInteger? value, String name) {
+  if (value == null) {
+    throw AssertionError('JCA RSA key has no $name');
+  }
+  value.releasedBy(arena);
+  return _jwkEncodeBase64UrlNoPadding(
+    _copyUnsignedRsaBigInteger(arena, value, name),
+  );
 }
 
 void _validateRsaJwk(
@@ -412,6 +569,40 @@ void _validateRsaKeyGenerationParameters(
       publicExponent != BigInt.from(65537)) {
     throw UnsupportedError('publicExponent is not supported; use 3 or 65537');
   }
+}
+
+void _validateRsaDerEncoding(Uint8List keyData, String name) {
+  // JCA KeyFactory accepts a valid key followed by unused bytes. Check the
+  // outer DER sequence length so the entire caller-provided input is consumed.
+  _checkData(
+    keyData.length >= 2 && keyData.first == 0x30,
+    '$name must be a DER-encoded sequence',
+  );
+
+  final firstLengthByte = keyData[1];
+  var headerLength = 2;
+  var contentLength = 0;
+  if (firstLengthByte < 0x80) {
+    contentLength = firstLengthByte;
+  } else {
+    final lengthByteCount = firstLengthByte & 0x7f;
+    _checkData(lengthByteCount != 0, '$name uses an indefinite DER length');
+    _checkData(
+      lengthByteCount <= keyData.length - 2,
+      '$name has a truncated DER length',
+    );
+    _checkData(keyData[2] != 0, '$name has a non-minimal DER length');
+    headerLength += lengthByteCount;
+    for (var i = 0; i < lengthByteCount; i++) {
+      contentLength = (contentLength << 8) | keyData[2 + i];
+    }
+    _checkData(contentLength >= 0x80, '$name has a non-minimal DER length');
+  }
+
+  _checkData(
+    headerLength + contentLength == keyData.length,
+    '$name has trailing or truncated data',
+  );
 }
 
 FormatException _rsaKeyFormatException(

--- a/lib/src/impl_jni/impl_jni.rsa_common.dart
+++ b/lib/src/impl_jni/impl_jni.rsa_common.dart
@@ -16,10 +16,9 @@ part of 'impl_jni.dart';
 
 typedef _RsaKeyPairData = ({Uint8List privateKeyData, Uint8List publicKeyData});
 
-// Keep imported-key limits aligned with rsa_check_public_key(), which backs
-// the FFI implementation's RSA_check_key() validation. See:
-// third_party/boringssl/src/crypto/fipsmodule/rsa/rsa_impl.cc.inc
-const _rsaMinModulusBits = 512;
+// Keep import prevalidation aligned with the package-wide key-generation range.
+// Providers may impose a stronger minimum when constructing or generating keys.
+const _rsaMinModulusBits = 256;
 const _rsaMaxModulusBits = 16384;
 const _rsaMaxPublicExponentBits = 33;
 

--- a/lib/src/impl_jni/impl_jni.rsassapkcs1v15.dart
+++ b/lib/src/impl_jni/impl_jni.rsassapkcs1v15.dart
@@ -1,4 +1,4 @@
-// Copyright 2026 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/src/impl_jni/impl_jni.rsassapkcs1v15.dart
+++ b/lib/src/impl_jni/impl_jni.rsassapkcs1v15.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,18 +22,89 @@ final class _StaticRsaSsaPkcs1V15PrivateKeyImpl
   Future<RsaSsaPkcs1V15PrivateKeyImpl> importPkcs8Key(
     List<int> keyData,
     HashImpl hash,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    return _RsaSsaPkcs1V15PrivateKeyImpl(
+      _importPkcs8RsaPrivateKey(_asUint8List(keyData)),
+      h,
+    );
+  }
 
   @override
   Future<RsaSsaPkcs1V15PrivateKeyImpl> importJsonWebKey(
     Map<String, dynamic> jwk,
     HashImpl hash,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    return _RsaSsaPkcs1V15PrivateKeyImpl(
+      _importJwkRsaPrivateKey(
+        jwk,
+        expectedAlg: h._rsassaPkcs1v15JwkAlg,
+        expectedUse: 'sig',
+      ),
+      h,
+    );
+  }
 
   @override
   Future<(RsaSsaPkcs1V15PrivateKeyImpl, RsaSsaPkcs1V15PublicKeyImpl)>
-  generateKey(int modulusLength, BigInt publicExponent, HashImpl hash) =>
-      throw UnimplementedError('Not implemented');
+  generateKey(int modulusLength, BigInt publicExponent, HashImpl hash) async {
+    final h = _rsaHashFromHash(hash);
+    final keyPair = await _generateRsaKeyPair(modulusLength, publicExponent);
+    return (
+      _RsaSsaPkcs1V15PrivateKeyImpl(keyPair.privateKeyData, h),
+      _RsaSsaPkcs1V15PublicKeyImpl(keyPair.publicKeyData, h),
+    );
+  }
+}
+
+final class _RsaSsaPkcs1V15PrivateKeyImpl
+    implements RsaSsaPkcs1V15PrivateKeyImpl {
+  _RsaSsaPkcs1V15PrivateKeyImpl(Uint8List keyData, this._hash)
+    : _keyData = Uint8List.fromList(keyData);
+
+  final Uint8List _keyData;
+  final _HashImpl _hash;
+
+  @override
+  Future<Uint8List> signBytes(List<int> data) => signStream(Stream.value(data));
+
+  @override
+  Future<Uint8List> signStream(Stream<List<int>> data) async {
+    final arena = jni.Arena();
+    try {
+      final key = _rsaPrivateKeyFromPkcs8(arena, _keyData);
+      final signature = _createRsaSsaPkcs1V15Signature(arena, _hash);
+      signature.initSign(key);
+
+      final buffer = jni.JByteArray(_defaultChunkSize)..releasedBy(arena);
+      await for (final chunk in data) {
+        _updateRsaSignature(signature, buffer, chunk);
+      }
+
+      final result = signature.sign();
+      if (result == null) {
+        throw AssertionError('JCA RSASSA-PKCS1-v1_5 returned null');
+      }
+      result.releasedBy(arena);
+      return result.copyToDartBytes();
+    } on jni.JThrowable catch (e) {
+      throw _rsaOperationError(e, 'JCA RSASSA-PKCS1-v1_5 signing failed');
+    } finally {
+      arena.releaseAll();
+    }
+  }
+
+  @override
+  Future<Uint8List> exportPkcs8Key() async => Uint8List.fromList(_keyData);
+
+  @override
+  Future<Map<String, dynamic>> exportJsonWebKey() async =>
+      _exportJwkRsaPrivateKey(
+        _keyData,
+        jwkAlg: _hash._rsassaPkcs1v15JwkAlg,
+        jwkUse: 'sig',
+      );
 }
 
 final class _StaticRsaSsaPkcs1V15PublicKeyImpl
@@ -44,11 +115,108 @@ final class _StaticRsaSsaPkcs1V15PublicKeyImpl
   Future<RsaSsaPkcs1V15PublicKeyImpl> importSpkiKey(
     List<int> keyData,
     HashImpl hash,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    return _RsaSsaPkcs1V15PublicKeyImpl(
+      _importSpkiRsaPublicKey(_asUint8List(keyData)),
+      h,
+    );
+  }
 
   @override
   Future<RsaSsaPkcs1V15PublicKeyImpl> importJsonWebKey(
     Map<String, dynamic> jwk,
     HashImpl hash,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    return _RsaSsaPkcs1V15PublicKeyImpl(
+      _importJwkRsaPublicKey(
+        jwk,
+        expectedAlg: h._rsassaPkcs1v15JwkAlg,
+        expectedUse: 'sig',
+      ),
+      h,
+    );
+  }
+}
+
+final class _RsaSsaPkcs1V15PublicKeyImpl
+    implements RsaSsaPkcs1V15PublicKeyImpl {
+  _RsaSsaPkcs1V15PublicKeyImpl(Uint8List keyData, this._hash)
+    : _keyData = Uint8List.fromList(keyData);
+
+  final Uint8List _keyData;
+  final _HashImpl _hash;
+
+  @override
+  Future<bool> verifyBytes(List<int> signature, List<int> data) =>
+      verifyStream(signature, Stream.value(data));
+
+  @override
+  Future<bool> verifyStream(List<int> signature, Stream<List<int>> data) async {
+    final arena = jni.Arena();
+    try {
+      final key = _rsaPublicKeyFromSpki(arena, _keyData);
+      final verifier = _createRsaSsaPkcs1V15Signature(arena, _hash);
+      verifier.initVerify(key);
+
+      final buffer = jni.JByteArray(_defaultChunkSize)..releasedBy(arena);
+      await for (final chunk in data) {
+        _updateRsaSignature(verifier, buffer, chunk);
+      }
+
+      final suppliedSignature = arena.copyToJByteArray(_asUint8List(signature));
+      try {
+        return verifier.verify(suppliedSignature);
+      } on jni.JThrowable catch (e) {
+        // Invalid signature encodings are verification failures, not operation
+        // failures. Release the attacker-triggerable Java throwable promptly.
+        e.release();
+        return false;
+      }
+    } on jni.JThrowable catch (e) {
+      throw _rsaOperationError(e, 'JCA RSASSA-PKCS1-v1_5 verification failed');
+    } finally {
+      arena.releaseAll();
+    }
+  }
+
+  @override
+  Future<Uint8List> exportSpkiKey() async => Uint8List.fromList(_keyData);
+
+  @override
+  Future<Map<String, dynamic>> exportJsonWebKey() async =>
+      _exportJwkRsaPublicKey(
+        _keyData,
+        jwkAlg: _hash._rsassaPkcs1v15JwkAlg,
+        jwkUse: 'sig',
+      );
+}
+
+Signature _createRsaSsaPkcs1V15Signature(jni.Arena arena, _HashImpl hash) {
+  final algorithm = hash._rsassaPkcs1v15JcaName.toJString()..releasedBy(arena);
+  final signature = Signature.getInstance(algorithm);
+  if (signature == null) {
+    throw AssertionError(
+      'JCA Signature(${hash._rsassaPkcs1v15JcaName}) returned null',
+    );
+  }
+  signature.releasedBy(arena);
+  return signature;
+}
+
+void _updateRsaSignature(
+  Signature signature,
+  jni.JByteArray buffer,
+  List<int> chunk,
+) {
+  final bytes = _asUint8List(chunk);
+  var offset = 0;
+  while (offset < bytes.length) {
+    final remaining = bytes.length - offset;
+    final length = math.min(remaining, _defaultChunkSize);
+    buffer.setRange(0, length, bytes, offset);
+    signature.update$2(buffer, 0, length);
+    offset += length;
+  }
 }

--- a/lib/src/impl_jni/impl_jni.rsassapkcs1v15.dart
+++ b/lib/src/impl_jni/impl_jni.rsassapkcs1v15.dart
@@ -68,8 +68,7 @@ final class _RsaSsaPkcs1V15PrivateKeyImpl
     implements RsaSsaPkcs1V15PrivateKeyImpl {
   _RsaSsaPkcs1V15PrivateKeyImpl(this._key, this._hash);
 
-  // Retained on the caller isolate; its JGlobalReference finalizer owns release.
-  final jni.JObject _key;
+  final _JcaKeyOwner _key;
   final _HashImpl _hash;
 
   @override
@@ -80,7 +79,7 @@ final class _RsaSsaPkcs1V15PrivateKeyImpl
     final arena = jni.Arena();
     try {
       final signature = _createRsaSsaPkcs1V15Signature(arena, _hash);
-      signature.initSign(_key);
+      signature.initSign(_key.key);
 
       final buffer = jni.JByteArray(_defaultChunkSize)..releasedBy(arena);
       await for (final chunk in data) {
@@ -150,8 +149,7 @@ final class _RsaSsaPkcs1V15PublicKeyImpl
     implements RsaSsaPkcs1V15PublicKeyImpl {
   _RsaSsaPkcs1V15PublicKeyImpl(this._key, this._hash);
 
-  // Retained on the caller isolate; its JGlobalReference finalizer owns release.
-  final jni.JObject _key;
+  final _JcaKeyOwner _key;
   final _HashImpl _hash;
 
   @override
@@ -163,7 +161,7 @@ final class _RsaSsaPkcs1V15PublicKeyImpl
     final arena = jni.Arena();
     try {
       final verifier = _createRsaSsaPkcs1V15Signature(arena, _hash);
-      verifier.initVerify(_key);
+      verifier.initVerify(_key.key);
 
       final buffer = jni.JByteArray(_defaultChunkSize)..releasedBy(arena);
       await for (final chunk in data) {

--- a/lib/src/impl_jni/impl_jni.rsassapkcs1v15.dart
+++ b/lib/src/impl_jni/impl_jni.rsassapkcs1v15.dart
@@ -52,18 +52,24 @@ final class _StaticRsaSsaPkcs1V15PrivateKeyImpl
     final h = _rsaHashFromHash(hash);
     final keyPair = await _generateRsaKeyPair(modulusLength, publicExponent);
     return (
-      _RsaSsaPkcs1V15PrivateKeyImpl(keyPair.privateKeyData, h),
-      _RsaSsaPkcs1V15PublicKeyImpl(keyPair.publicKeyData, h),
+      _RsaSsaPkcs1V15PrivateKeyImpl(
+        _importPkcs8RsaPrivateKey(keyPair.privateKeyData),
+        h,
+      ),
+      _RsaSsaPkcs1V15PublicKeyImpl(
+        _importSpkiRsaPublicKey(keyPair.publicKeyData),
+        h,
+      ),
     );
   }
 }
 
 final class _RsaSsaPkcs1V15PrivateKeyImpl
     implements RsaSsaPkcs1V15PrivateKeyImpl {
-  _RsaSsaPkcs1V15PrivateKeyImpl(Uint8List keyData, this._hash)
-    : _keyData = Uint8List.fromList(keyData);
+  _RsaSsaPkcs1V15PrivateKeyImpl(this._key, this._hash);
 
-  final Uint8List _keyData;
+  // Retained on the caller isolate; its JGlobalReference finalizer owns release.
+  final jni.JObject _key;
   final _HashImpl _hash;
 
   @override
@@ -73,9 +79,8 @@ final class _RsaSsaPkcs1V15PrivateKeyImpl
   Future<Uint8List> signStream(Stream<List<int>> data) async {
     final arena = jni.Arena();
     try {
-      final key = _rsaPrivateKeyFromPkcs8(arena, _keyData);
       final signature = _createRsaSsaPkcs1V15Signature(arena, _hash);
-      signature.initSign(key);
+      signature.initSign(_key);
 
       final buffer = jni.JByteArray(_defaultChunkSize)..releasedBy(arena);
       await for (final chunk in data) {
@@ -96,12 +101,13 @@ final class _RsaSsaPkcs1V15PrivateKeyImpl
   }
 
   @override
-  Future<Uint8List> exportPkcs8Key() async => Uint8List.fromList(_keyData);
+  Future<Uint8List> exportPkcs8Key() async =>
+      _exportEncodedRsaKey(_key, 'private');
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async =>
       _exportJwkRsaPrivateKey(
-        _keyData,
+        _key,
         jwkAlg: _hash._rsassaPkcs1v15JwkAlg,
         jwkUse: 'sig',
       );
@@ -142,10 +148,10 @@ final class _StaticRsaSsaPkcs1V15PublicKeyImpl
 
 final class _RsaSsaPkcs1V15PublicKeyImpl
     implements RsaSsaPkcs1V15PublicKeyImpl {
-  _RsaSsaPkcs1V15PublicKeyImpl(Uint8List keyData, this._hash)
-    : _keyData = Uint8List.fromList(keyData);
+  _RsaSsaPkcs1V15PublicKeyImpl(this._key, this._hash);
 
-  final Uint8List _keyData;
+  // Retained on the caller isolate; its JGlobalReference finalizer owns release.
+  final jni.JObject _key;
   final _HashImpl _hash;
 
   @override
@@ -156,9 +162,8 @@ final class _RsaSsaPkcs1V15PublicKeyImpl
   Future<bool> verifyStream(List<int> signature, Stream<List<int>> data) async {
     final arena = jni.Arena();
     try {
-      final key = _rsaPublicKeyFromSpki(arena, _keyData);
       final verifier = _createRsaSsaPkcs1V15Signature(arena, _hash);
-      verifier.initVerify(key);
+      verifier.initVerify(_key);
 
       final buffer = jni.JByteArray(_defaultChunkSize)..releasedBy(arena);
       await for (final chunk in data) {
@@ -182,12 +187,13 @@ final class _RsaSsaPkcs1V15PublicKeyImpl
   }
 
   @override
-  Future<Uint8List> exportSpkiKey() async => Uint8List.fromList(_keyData);
+  Future<Uint8List> exportSpkiKey() async =>
+      _exportEncodedRsaKey(_key, 'public');
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async =>
       _exportJwkRsaPublicKey(
-        _keyData,
+        _key,
         jwkAlg: _hash._rsassaPkcs1v15JwkAlg,
         jwkUse: 'sig',
       );

--- a/lib/src/impl_jni/impl_jni.utils.dart
+++ b/lib/src/impl_jni/impl_jni.utils.dart
@@ -16,6 +16,23 @@ part of 'impl_jni.dart';
 
 const _defaultChunkSize = 4096;
 
+/// Owns a JCA key whose lifetime extends beyond one JNI operation.
+///
+/// `package:jni` owns the underlying `JGlobalReference` and deletes it through
+/// its finalizer. This wrapper only prevents a live JCA key from crossing an
+/// isolate boundary; it must not add another finalizer or release [key]
+/// explicitly.
+@pragma('vm:isolate-unsendable')
+final class _JcaKeyOwner {
+  _JcaKeyOwner(this.key);
+
+  final jni.JObject key;
+
+  // TODO: Stress-test persistent-key churn. package:jni currently registers
+  // JGlobalReference finalizers with externalSize 0, so JVM key memory does
+  // not contribute to Dart VM GC pressure.
+}
+
 void _checkData(bool condition, String message) {
   if (!condition) {
     throw FormatException(message);

--- a/test/impl_jni_rsassapkcs1v15_test.dart
+++ b/test/impl_jni_rsassapkcs1v15_test.dart
@@ -47,7 +47,7 @@ void main() {
     'JCA RSASSA-PKCS1-v1_5 keys and signatures interoperate with FFI',
     () async {
       final chunks = <Uint8List>[
-        utf8.encode('RSASSA-PKCS1-v1_5 '),
+        Uint8List.fromList(List<int>.generate(9000, (i) => i & 0xff)),
         utf8.encode('interoperability'),
       ];
       final pkcs8 = await privateKey.exportPkcs8Key();
@@ -91,6 +91,117 @@ void main() {
       isFalse,
     );
   }, skip: skipReason);
+
+  test('JCA RSA imports reject trailing DER data', () async {
+    final pkcs8 = await privateKey.exportPkcs8Key();
+    final spki = await publicKey.exportSpkiKey();
+
+    await expectLater(
+      jni_impl.webCryptImpl.rsaSsaPkcs1v15PrivateKey.importPkcs8Key(
+        Uint8List.fromList([...pkcs8, 0]),
+        jni_impl.webCryptImpl.sha256,
+      ),
+      throwsA(isA<FormatException>()),
+    );
+    await expectLater(
+      jni_impl.webCryptImpl.rsaSsaPkcs1v15PublicKey.importSpkiKey(
+        Uint8List.fromList([...spki, 0]),
+        jni_impl.webCryptImpl.sha256,
+      ),
+      throwsA(isA<FormatException>()),
+    );
+  }, skip: skipReason);
+
+  test('JCA RSA public imports validate the modulus and exponent', () async {
+    final publicJwk = await publicKey.exportJsonWebKey();
+
+    final invalidExponent = Map<String, dynamic>.of(publicJwk)..['e'] = 'BA';
+    await expectLater(
+      jni_impl.webCryptImpl.rsaSsaPkcs1v15PublicKey.importJsonWebKey(
+        invalidExponent,
+        jni_impl.webCryptImpl.sha256,
+      ),
+      throwsA(isA<FormatException>()),
+    );
+
+    final oversizedExponent = Map<String, dynamic>.of(publicJwk)
+      ..['e'] = base64Url
+          .encode(<int>[0x02, 0x00, 0x00, 0x00, 0x01])
+          .replaceAll('=', '');
+    await expectLater(
+      jni_impl.webCryptImpl.rsaSsaPkcs1v15PublicKey.importJsonWebKey(
+        oversizedExponent,
+        jni_impl.webCryptImpl.sha256,
+      ),
+      throwsA(isA<FormatException>()),
+    );
+
+    final invalidModulus = Map<String, dynamic>.of(publicJwk)
+      ..['n'] = _clearLastBit(publicJwk['n'] as String);
+    await expectLater(
+      jni_impl.webCryptImpl.rsaSsaPkcs1v15PublicKey.importJsonWebKey(
+        invalidModulus,
+        jni_impl.webCryptImpl.sha256,
+      ),
+      throwsA(isA<FormatException>()),
+    );
+
+    final invalidSpki = Uint8List.fromList(await publicKey.exportSpkiKey())
+      ..last &= 0xfe;
+    await expectLater(
+      jni_impl.webCryptImpl.rsaSsaPkcs1v15PublicKey.importSpkiKey(
+        invalidSpki,
+        jni_impl.webCryptImpl.sha256,
+      ),
+      throwsA(isA<FormatException>()),
+    );
+  }, skip: skipReason);
+
+  test('JCA RSA private JWK import validates key components', () async {
+    final privateJwk = await privateKey.exportJsonWebKey();
+
+    final invalidExponent = Map<String, dynamic>.of(privateJwk)..['e'] = 'Aw';
+    await expectLater(
+      jni_impl.webCryptImpl.rsaSsaPkcs1v15PrivateKey.importJsonWebKey(
+        invalidExponent,
+        jni_impl.webCryptImpl.sha256,
+      ),
+      throwsA(isA<FormatException>()),
+    );
+
+    final invalidPrimeExponent = Map<String, dynamic>.of(privateJwk)
+      ..['dp'] = _flipLastBase64UrlByte(privateJwk['dp'] as String);
+    await expectLater(
+      jni_impl.webCryptImpl.rsaSsaPkcs1v15PrivateKey.importJsonWebKey(
+        invalidPrimeExponent,
+        jni_impl.webCryptImpl.sha256,
+      ),
+      throwsA(isA<FormatException>()),
+    );
+  }, skip: skipReason);
+
+  test(
+    'JCA RSASSA-PKCS1-v1_5 supports SHA-1 metadata and signatures',
+    () async {
+      final sha1Private = await jni_impl.webCryptImpl.rsaSsaPkcs1v15PrivateKey
+          .importPkcs8Key(
+            await privateKey.exportPkcs8Key(),
+            jni_impl.webCryptImpl.sha1,
+          );
+      final sha1Public = await jni_impl.webCryptImpl.rsaSsaPkcs1v15PublicKey
+          .importSpkiKey(
+            await publicKey.exportSpkiKey(),
+            jni_impl.webCryptImpl.sha1,
+          );
+      final data = utf8.encode('SHA-1 compatibility');
+      final signature = await sha1Private.signBytes(data);
+
+      expect(await sha1Public.verifyBytes(signature, data), isTrue);
+      expect((await sha1Private.exportJsonWebKey())['alg'], 'RS1');
+      expect((await sha1Public.exportJsonWebKey())['alg'], 'RS1');
+    },
+    skip: skipReason,
+  );
 
   test('JCA RSASSA-PKCS1-v1_5 exports and validates RSA JWK values', () async {
     final privateJwk = await privateKey.exportJsonWebKey();
@@ -143,4 +254,23 @@ String _prependZeroToBase64Url(String encoded) {
   );
   final bytes = base64Url.decode(padded);
   return base64Url.encode(<int>[0, ...bytes]).replaceAll('=', '');
+}
+
+String _flipLastBase64UrlByte(String encoded) {
+  final padded = encoded.padRight(
+    encoded.length + ((4 - encoded.length % 4) % 4),
+    '=',
+  );
+  final bytes = base64Url.decode(padded);
+  bytes[bytes.length - 1] ^= 0x01;
+  return base64Url.encode(bytes).replaceAll('=', '');
+}
+
+String _clearLastBit(String encoded) {
+  final padded = encoded.padRight(
+    encoded.length + ((4 - encoded.length % 4) % 4),
+    '=',
+  );
+  final bytes = base64Url.decode(padded)..last &= 0xfe;
+  return base64Url.encode(bytes).replaceAll('=', '');
 }

--- a/test/impl_jni_rsassapkcs1v15_test.dart
+++ b/test/impl_jni_rsassapkcs1v15_test.dart
@@ -1,0 +1,146 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:webcrypto/src/impl_ffi/impl_ffi.dart' as ffi_impl;
+import 'package:webcrypto/src/impl_interface/impl_interface.dart';
+import 'package:webcrypto/src/impl_jni/impl_jni.dart' as jni_impl;
+
+import 'src/jni_test_setup.dart'
+    if (dart.library.io) 'src/jni_test_setup_io.dart';
+
+void main() {
+  final skipReason = jniHelperSetupSkipReason;
+  late RsaSsaPkcs1V15PrivateKeyImpl privateKey;
+  late RsaSsaPkcs1V15PublicKeyImpl publicKey;
+
+  setUpAll(() async {
+    if (skipReason != null) {
+      return;
+    }
+
+    spawnJniForDesktopTests();
+    final keyPair = await jni_impl.webCryptImpl.rsaSsaPkcs1v15PrivateKey
+        .generateKey(2048, BigInt.from(65537), jni_impl.webCryptImpl.sha256);
+    privateKey = keyPair.$1;
+    publicKey = keyPair.$2;
+  });
+
+  test(
+    'JCA RSASSA-PKCS1-v1_5 keys and signatures interoperate with FFI',
+    () async {
+      final chunks = <Uint8List>[
+        utf8.encode('RSASSA-PKCS1-v1_5 '),
+        utf8.encode('interoperability'),
+      ];
+      final pkcs8 = await privateKey.exportPkcs8Key();
+      final spki = await publicKey.exportSpkiKey();
+      final ffiPrivateKey = await ffi_impl.webCryptImpl.rsaSsaPkcs1v15PrivateKey
+          .importPkcs8Key(pkcs8, ffi_impl.webCryptImpl.sha256);
+      final ffiPublicKey = await ffi_impl.webCryptImpl.rsaSsaPkcs1v15PublicKey
+          .importSpkiKey(spki, ffi_impl.webCryptImpl.sha256);
+
+      final jcaSignature = await privateKey.signStream(
+        Stream.fromIterable(chunks),
+      );
+      final ffiSignature = await ffiPrivateKey.signStream(
+        Stream.fromIterable(chunks),
+      );
+
+      expect(jcaSignature, ffiSignature);
+      expect(
+        await ffiPublicKey.verifyStream(
+          jcaSignature,
+          Stream.fromIterable(chunks),
+        ),
+        isTrue,
+      );
+      expect(
+        await publicKey.verifyStream(ffiSignature, Stream.fromIterable(chunks)),
+        isTrue,
+      );
+    },
+    skip: skipReason,
+  );
+
+  test('JCA RSASSA-PKCS1-v1_5 rejects malformed signatures', () async {
+    final data = utf8.encode('message');
+    final signature = await privateKey.signBytes(data);
+    final modified = Uint8List.fromList(signature)..[0] ^= 0x01;
+
+    expect(await publicKey.verifyBytes(modified, data), isFalse);
+    expect(
+      await publicKey.verifyBytes(Uint8List.sublistView(signature, 1), data),
+      isFalse,
+    );
+  }, skip: skipReason);
+
+  test('JCA RSASSA-PKCS1-v1_5 exports and validates RSA JWK values', () async {
+    final privateJwk = await privateKey.exportJsonWebKey();
+    final publicJwk = await publicKey.exportJsonWebKey();
+
+    expect(privateJwk['kty'], 'RSA');
+    expect(privateJwk['use'], 'sig');
+    expect(privateJwk['alg'], 'RS256');
+    expect(
+      privateJwk.keys,
+      containsAll(<String>['d', 'p', 'q', 'dp', 'dq', 'qi']),
+    );
+    expect(publicJwk['kty'], 'RSA');
+    expect(publicJwk['use'], 'sig');
+    expect(publicJwk['alg'], 'RS256');
+    expect(publicJwk.keys, isNot(contains('d')));
+
+    final importedPrivate = await jni_impl.webCryptImpl.rsaSsaPkcs1v15PrivateKey
+        .importJsonWebKey(privateJwk, jni_impl.webCryptImpl.sha256);
+    final importedPublic = await jni_impl.webCryptImpl.rsaSsaPkcs1v15PublicKey
+        .importJsonWebKey(publicJwk, jni_impl.webCryptImpl.sha256);
+    final data = utf8.encode('JWK round trip');
+    final signature = await importedPrivate.signBytes(data);
+    expect(await importedPublic.verifyBytes(signature, data), isTrue);
+
+    final invalidPublicJwk = Map<String, dynamic>.of(publicJwk);
+    invalidPublicJwk['n'] = _prependZeroToBase64Url(
+      invalidPublicJwk['n'] as String,
+    );
+    await expectLater(
+      jni_impl.webCryptImpl.rsaSsaPkcs1v15PublicKey.importJsonWebKey(
+        invalidPublicJwk,
+        jni_impl.webCryptImpl.sha256,
+      ),
+      throwsA(
+        isA<FormatException>().having(
+          (e) => e.message,
+          'message',
+          contains('must not have leading zeros'),
+        ),
+      ),
+    );
+  }, skip: skipReason);
+}
+
+String _prependZeroToBase64Url(String encoded) {
+  final padded = encoded.padRight(
+    encoded.length + ((4 - encoded.length % 4) % 4),
+    '=',
+  );
+  final bytes = base64Url.decode(padded);
+  return base64Url.encode(<int>[0, ...bytes]).replaceAll('=', '');
+}

--- a/test/impl_jni_rsassapkcs1v15_test.dart
+++ b/test/impl_jni_rsassapkcs1v15_test.dart
@@ -16,6 +16,7 @@
 library;
 
 import 'dart:convert';
+import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:test/test.dart';
@@ -203,6 +204,20 @@ void main() {
     skip: skipReason,
   );
 
+  test('JCA RSA key wrappers cannot cross isolate boundaries', () async {
+    for (final key in <Object>[privateKey, publicKey]) {
+      final ready = ReceivePort();
+      final isolate = await Isolate.spawn(_waitForMessage, ready.sendPort);
+      try {
+        final destination = await ready.first as SendPort;
+        expect(() => destination.send(key), throwsA(isA<ArgumentError>()));
+      } finally {
+        isolate.kill(priority: Isolate.immediate);
+        ready.close();
+      }
+    }
+  }, skip: skipReason);
+
   test('JCA RSASSA-PKCS1-v1_5 exports and validates RSA JWK values', () async {
     final privateJwk = await privateKey.exportJsonWebKey();
     final publicJwk = await publicKey.exportJsonWebKey();
@@ -245,6 +260,12 @@ void main() {
       ),
     );
   }, skip: skipReason);
+}
+
+Future<void> _waitForMessage(SendPort ready) async {
+  final messages = ReceivePort();
+  ready.send(messages.sendPort);
+  await messages.first;
 }
 
 String _prependZeroToBase64Url(String encoded) {


### PR DESCRIPTION
## Summary

Adds the JNI/JCA RSASSA-PKCS1-v1_5 implementation on top of the Android JCA backend.

This PR implements:
- RSA key generation with public exponents 3 and 65537
- PKCS#8 private-key and SPKI public-key import/export
- RSA private and public JWK import/export with RS1, RS256, RS384, and RS512 metadata
- strict DER consumption and RSA public/private component validation
- byte and streaming signing and verification through JCA `Signature`
- reusable fixed-size JNI buffers for stream processing
- malformed-signature handling as verification failure
- deterministic JNI reference and throwable cleanup
- focused desktop JNI tests and an Android smoke test

## Known Limitations

- RSA key-generation support remains provider-dependent within the package-wide accepted range. Desktop SunJCE rejects 256-bit generation; the 2048- and 3072-bit generation cases exercised by the shared suite pass.

## Testing

Desktop JNI setup, if it has not been run already:
- dart run jni:setup

Verified:
- dart analyze
- dart test test/impl_jni_rsassapkcs1v15_test.dart
- dart test test/webcrypto_test.dart -p vm -n RSASSA-PKCS1-v1_5
- flutter test integration_test/jni_rsassapkcs1v15_test.dart -d emulator-name