### PR TITLE
chore: mark unsupported code paths with coverage:ignore

### DIFF
--- a/lib/src/boringssl/lookup/utils.dart
+++ b/lib/src/boringssl/lookup/utils.dart
@@ -29,10 +29,12 @@ String get libraryFileName {
   if (Platform.isMacOS) {
     return 'lib$libraryName.dylib';
   }
+  // coverage:ignore-start
   throw UnsupportedError(
     'Platform ${Platform.operatingSystem} is unsupported or embed '
     'the binary webcrypto library for package:webcrypto',
   );
+  // coverage:ignore-end
 }
 
 /// Look for the webcrypto binary library in the `.dart_tool/webcrypto/` folder.

--- a/lib/src/impl_ffi/impl_ffi.aes_common.dart
+++ b/lib/src/impl_ffi/impl_ffi.aes_common.dart
@@ -18,7 +18,9 @@ Uint8List _aesImportRawKey(List<int> keyData) {
   if (keyData.length == 24) {
     // 192-bit AES is intentionally unsupported, see https://crbug.com/533699
     // If not supported in Chrome, there is not reason to support it in Dart.
+    // coverage:ignore-start
     throw UnsupportedError('192-bit AES keys are not supported');
+    // coverage:ignore-end
   }
   if (keyData.length != 16 && keyData.length != 32) {
     throw const FormatException('keyData for AES must be 128 or 256 bits');
@@ -43,7 +45,9 @@ Uint8List _aesImportJwkKey(
   if (keyData.length == 24) {
     // 192-bit AES is intentionally unsupported, see https://crbug.com/533699
     // If not supported in Chrome, there is not reason to support it in Dart.
+    // coverage:ignore-start
     throw UnsupportedError('192-bit AES keys are not supported');
+    // coverage:ignore-end
   }
   checkJwk(
     keyData.length == 16 || keyData.length == 32,
@@ -82,7 +86,9 @@ Uint8List _aesGenerateKey(int length) {
   if (length == 192) {
     // 192-bit AES is intentionally unsupported, see https://crbug.com/533699
     // If not supported in Chrome, there is not reason to support it in Dart.
+    // coverage:ignore-start
     throw UnsupportedError('192-bit AES keys are not supported');
+    // coverage:ignore-end
   }
   if (length != 128 && length != 256) {
     throw const FormatException('keyData for AES must be 128 or 256 bits');

--- a/lib/src/impl_ffi/impl_ffi.ec_common.dart
+++ b/lib/src/impl_ffi/impl_ffi.ec_common.dart
@@ -26,7 +26,9 @@ int _ecCurveToNID(EllipticCurve curve) {
     return NID_secp521r1;
   }
   // This should never happen!
+  // coverage:ignore-start
   throw UnsupportedError('curve "$curve" is not supported');
+  // coverage:ignore-end
 }
 
 /// Get [EllipticCurve] from matching BoringSSL `ssl.NID_...`.
@@ -41,7 +43,9 @@ EllipticCurve _ecCurveFromNID(int nid) {
     return EllipticCurve.p521;
   }
   // This should never happen!
+  // coverage:ignore-start
   throw operationError('internal error detecting curve');
+  // coverage:ignore-end
 }
 
 String _ecCurveToJwkCrv(EllipticCurve curve) {
@@ -55,7 +59,9 @@ String _ecCurveToJwkCrv(EllipticCurve curve) {
     return 'P-521';
   }
   // This should never happen!
+  // coverage:ignore-start
   throw UnsupportedError('curve "$curve" is not supported');
+  // coverage:ignore-end
 }
 
 /// Perform some post-import validation for EC keys.

--- a/lib/src/impl_ffi/impl_ffi.ecdsa.dart
+++ b/lib/src/impl_ffi/impl_ffi.ecdsa.dart
@@ -29,7 +29,9 @@ String _ecdsaCurveToJwkAlg(EllipticCurve curve) {
     return 'ES512';
   }
   // This should never happen!
+  // coverage:ignore-start
   throw UnsupportedError('curve "$curve" is not supported');
+  // coverage:ignore-end
 }
 
 Future<EcdsaPrivateKeyImpl> ecdsaPrivateKey_importPkcs8Key(

--- a/lib/src/impl_js/impl_js.utils.dart
+++ b/lib/src/impl_js/impl_js.utils.dart
@@ -45,8 +45,10 @@ String _curveToName(EllipticCurve curve) {
       return 'P-521';
   }
   // This should never happen.
+  // coverage:ignore-start
   // ignore: dead_code
   throw AssertionError('Unknown curve "$curve"');
+  // coverage:ignore-end
 }
 
 Object _translateDomException(

--- a/lib/src/impl_stub/impl_stub.aescbc.dart
+++ b/lib/src/impl_stub/impl_stub.aescbc.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 part of 'impl_stub.dart';
 
 final class _StaticAesCbcSecretKeyImpl implements StaticAesCbcSecretKeyImpl {

--- a/lib/src/impl_stub/impl_stub.aesctr.dart
+++ b/lib/src/impl_stub/impl_stub.aesctr.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 part of 'impl_stub.dart';
 
 final class _StaticAesCtrSecretKeyImpl implements StaticAesCtrSecretKeyImpl {

--- a/lib/src/impl_stub/impl_stub.aesgcm.dart
+++ b/lib/src/impl_stub/impl_stub.aesgcm.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 part of 'impl_stub.dart';
 
 final class _StaticAesGcmSecretKeyImpl implements StaticAesGcmSecretKeyImpl {

--- a/lib/src/impl_stub/impl_stub.dart
+++ b/lib/src/impl_stub/impl_stub.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 library;
 
 import 'dart:typed_data';

--- a/lib/src/impl_stub/impl_stub.digest.dart
+++ b/lib/src/impl_stub/impl_stub.digest.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 part of 'impl_stub.dart';
 
 final class _HashImpl implements HashImpl {

--- a/lib/src/impl_stub/impl_stub.ecdh.dart
+++ b/lib/src/impl_stub/impl_stub.ecdh.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 part of 'impl_stub.dart';
 
 final class _StaticEcdhPrivateKeyImpl implements StaticEcdhPrivateKeyImpl {

--- a/lib/src/impl_stub/impl_stub.ecdsa.dart
+++ b/lib/src/impl_stub/impl_stub.ecdsa.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 part of 'impl_stub.dart';
 
 final class _StaticEcdsaPrivateKeyImpl implements StaticEcdsaPrivateKeyImpl {

--- a/lib/src/impl_stub/impl_stub.hkdf.dart
+++ b/lib/src/impl_stub/impl_stub.hkdf.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 part of 'impl_stub.dart';
 
 final class _StaticHkdfSecretKeyImpl implements StaticHkdfSecretKeyImpl {

--- a/lib/src/impl_stub/impl_stub.hmac.dart
+++ b/lib/src/impl_stub/impl_stub.hmac.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 part of 'impl_stub.dart';
 
 final class _StaticHmacSecretKeyImpl implements StaticHmacSecretKeyImpl {

--- a/lib/src/impl_stub/impl_stub.pbkdf2.dart
+++ b/lib/src/impl_stub/impl_stub.pbkdf2.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 part of 'impl_stub.dart';
 
 final class _StaticPbkdf2SecretKeyImpl implements StaticPbkdf2SecretKeyImpl {

--- a/lib/src/impl_stub/impl_stub.random.dart
+++ b/lib/src/impl_stub/impl_stub.random.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 part of 'impl_stub.dart';
 
 final class _RandomImpl implements RandomImpl {

--- a/lib/src/impl_stub/impl_stub.rsaoaep.dart
+++ b/lib/src/impl_stub/impl_stub.rsaoaep.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 part of 'impl_stub.dart';
 
 final class _StaticRsaOaepPrivateKeyImpl

--- a/lib/src/impl_stub/impl_stub.rsapss.dart
+++ b/lib/src/impl_stub/impl_stub.rsapss.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 part of 'impl_stub.dart';
 
 final class _StaticRsaPssPrivateKeyImpl implements StaticRsaPssPrivateKeyImpl {

--- a/lib/src/impl_stub/impl_stub.rsassapkcs1v15.dart
+++ b/lib/src/impl_stub/impl_stub.rsassapkcs1v15.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// coverage:ignore-file
 part of 'impl_stub.dart';
 
 final class _StaticRsaSsaPkcs1V15PrivateKeyImpl


### PR DESCRIPTION
Addresses part of #263.

## What

Adds `// coverage:ignore-*` markers to code paths documented in-source as intentionally unsupported or unreachable:

**Whole-file ignores — `lib/src/impl_stub/` (14 files)**

Marked with `// coverage:ignore-file`. This directory is loaded only via conditional import when *neither* `dart.library.ffi` nor `dart.library.js_interop` is available (see `lib/src/webcrypto/webcrypto.dart:27`). No real Dart runtime satisfies that condition, so every `throw UnimplementedError('Not implemented')` in the directory is unreachable at runtime by design.

**Block ignores — 4 files in `impl_ffi/`, `impl_js/`, and `boringssl/`**

Wrapped with `// coverage:ignore-start` / `// coverage:ignore-end`:

- Three `throw UnsupportedError('192-bit AES keys are not supported')` sites in `lib/src/impl_ffi/impl_ffi.aes_common.dart` (documented in-source as intentionally unsupported, see https://crbug.com/533699).
- The unsupported-platform fallback throw in `lib/src/boringssl/lookup/utils.dart` (fires only on operating systems outside {Windows, Linux, macOS}).
- Five "This should never happen!" curve fallbacks in `lib/src/impl_ffi/impl_ffi.ec_common.dart` (×3), `lib/src/impl_ffi/impl_ffi.ecdsa.dart`, and `lib/src/impl_js/impl_js.utils.dart` — dead-code fallbacks after exhaustive enum switches.

## Why

Per #263, these are candidates where "we don't want coverage" — code paths intentionally chosen not to test rather than defensively cover.

## Skipped intentionally

- `requireSubtleCrypto` (`lib/src/crypto_subtle.dart:82`) — the example cited in the issue. **Now has tests** at `test/crypto_subtle_test.dart:128` and `:141`, so ignore markers would silence real coverage. Left alone.
- `throw UnimplementedError('Only supports 65537 and 3 for now')` (`lib/src/crypto_subtle.dart:44`) — genuine TODO for future work, not an intentional gap. Left visible.

## Verification

- `dart format --output none --set-exit-if-changed .` passes.
- `dart analyze --fatal-warnings .` passes.
- Grep confirms no existing tests exercise the ignored throws (except `requireSubtleCrypto`, which is why it's excluded).
- Local test run was not possible on Windows: the native asset build fails with `CMake Error at CMakeLists.txt:19 (project): Generator Ninja does not support platform specification, but platform x64 was specified.` Working around it locally was out of scope for this change; relying on CI to validate.