### PR TITLE
docs: correct JWK use value for AES keys

### DIFF
--- a/lib/src/webcrypto/webcrypto.aescbc.dart
+++ b/lib/src/webcrypto/webcrypto.aescbc.dart
@@ -88,7 +88,7 @@ final class AesCbcSecretKey {
   /// {@macro AES:no-support-for-AES-192}
   ///
   /// If specified the `"use"` property of the imported [jwk] must be
-  /// `"use": "sig"`.
+  /// `"use": "enc"`.
   ///
   /// {@macro importJsonWebKey:throws-FormatException-if-jwk}
   ///

--- a/lib/src/webcrypto/webcrypto.aesctr.dart
+++ b/lib/src/webcrypto/webcrypto.aesctr.dart
@@ -85,7 +85,7 @@ final class AesCtrSecretKey {
   /// {@macro AES:no-support-for-AES-192}
   ///
   /// If specified the `"use"` property of the imported [jwk] must be
-  /// `"use": "sig"`.
+  /// `"use": "enc"`.
   ///
   /// {@macro importJsonWebKey:throws-FormatException-if-jwk}
   ///

--- a/lib/src/webcrypto/webcrypto.aesgcm.dart
+++ b/lib/src/webcrypto/webcrypto.aesgcm.dart
@@ -85,7 +85,7 @@ final class AesGcmSecretKey {
   /// {@macro AES:no-support-for-AES-192}
   ///
   /// If specified the `"use"` property of the imported [jwk] must be
-  /// `"use": "sig"`.
+  /// `"use": "enc"`.
   ///
   /// {@macro importJsonWebKey:throws-FormatException-if-jwk}
   ///


### PR DESCRIPTION
## Summary

Correct the documented JWK `use` value for AES-CBC, AES-CTR, and AES-GCM keys.

The documentation currently states that the `use` property must be `"sig"`, but AES keys are encryption keys and the implementation requires `"enc"` when the property is present.

## Changes

* Correct `AesCbcSecretKey.importJsonWebKey` documentation.
* Correct `AesCtrSecretKey.importJsonWebKey` documentation.
* Correct `AesGcmSecretKey.importJsonWebKey` documentation.

## Testing

Documentation-only change. No runtime behavior is modified.
