### PR TITLE
fix(ffi): reject private JWKs in RSA public imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.6.2-wip
 * Fixed JS interop to enable WebAssembly.
+* Fixed native RSA public-key JWK imports to reject private key material.
 
 # 0.6.1
 * Added Dart native build hooks and native asset lookup for the bundled

--- a/lib/src/impl_ffi/impl_ffi.rsa_common.dart
+++ b/lib/src/impl_ffi/impl_ffi.rsa_common.dart
@@ -86,6 +86,9 @@ _EvpPKey _importJwkRsaPrivateOrPublicKey(
       'use',
       'must be "$expectedUse", if present',
     );
+    if (!isPrivateKey) {
+      checkJwk(jwk.d == null, 'd', 'must not be present for a public key');
+    }
 
     // TODO: Consider rejecting private keys with 'use', as it's only valid for
     //       public keys according to the RFC -- maybe read the RFC again to be

--- a/test/rsa_jwk_validation_test.dart
+++ b/test/rsa_jwk_validation_test.dart
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:test/test.dart';
+import 'package:webcrypto/webcrypto.dart';
+
+final _throwsInvalidJwk = throwsA(
+  anyOf(isA<FormatException>(), isA<ArgumentError>()),
+);
+
+void main() {
+  late Map<String, dynamic> privateJwk;
+
+  setUpAll(() async {
+    final pair = await RsaOaepPrivateKey.generateKey(
+      1024,
+      BigInt.from(65537),
+      Hash.sha256,
+    );
+    privateJwk = await pair.privateKey.exportJsonWebKey();
+  });
+
+  test('RSA-OAEP public import rejects a private JWK', () async {
+    await expectLater(
+      RsaOaepPublicKey.importJsonWebKey(privateJwk, Hash.sha256),
+      _throwsInvalidJwk,
+    );
+  });
+
+  test('RSA-PSS public import rejects a private JWK', () async {
+    await expectLater(
+      RsaPssPublicKey.importJsonWebKey({
+        ...privateJwk,
+        'alg': 'PS256',
+        'use': 'sig',
+      }, Hash.sha256),
+      _throwsInvalidJwk,
+    );
+  });
+
+  test('RSASSA-PKCS1-v1_5 public import rejects a private JWK', () async {
+    await expectLater(
+      RsassaPkcs1V15PublicKey.importJsonWebKey({
+        ...privateJwk,
+        'alg': 'RS256',
+        'use': 'sig',
+      }, Hash.sha256),
+      _throwsInvalidJwk,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Reject RSA JWKs containing the private exponent when importing a public key through the native FFI backend.
- Add regression coverage for RSA-OAEP, RSA-PSS, and RSASSA-PKCS1-v1_5 public-key imports.

## Root cause

The shared native RSA JWK importer required `d` for private-key imports but did not require it to be absent for public-key imports. Public-key import methods therefore accepted private JWKs and silently discarded their private parameters.

The new validation rejects the JWK before allocating or parsing the native RSA key.

## Validation

- `dart analyze`
- `dart test test/rsa_jwk_validation_test.dart -p vm`
- `dart test test/rsa_jwk_validation_test.dart -p chrome`
- `dart test -p vm`

Fixes #332
