### PR TITLE
Upgrade native_toolchain_cmake to v0.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   ffi: ^2.0.0
   hooks: ^1.0.0
   code_assets: ^1.0.0
-  native_toolchain_cmake: ^0.2.4
+  native_toolchain_cmake: ^0.3.0
   meta: ^1.3.0
 
 dev_dependencies:


### PR DESCRIPTION
This new version improves Android SDK detection: https://github.com/rainyl/native_toolchain_cmake/issues/31