### PR TITLE
feat(impl_jni): add JCA RSA-OAEP implementation

### DIFF
--- a/example/webcrypto_demo_flutter_app/README.md
+++ b/example/webcrypto_demo_flutter_app/README.md
@@ -46,3 +46,10 @@ To run the Android JNI/JCA RSASSA-PKCS1-v1_5 smoke test:
 flutter test integration_test/jni_rsassapkcs1v15_test.dart \
   -d emulator-name
 ```
+
+To run the Android JNI/JCA RSA-OAEP smoke test:
+
+```sh
+flutter test integration_test/jni_rsaoaep_test.dart \
+  -d emulator-name
+```

--- a/example/webcrypto_demo_flutter_app/integration_test/jni_rsaoaep_test.dart
+++ b/example/webcrypto_demo_flutter_app/integration_test/jni_rsaoaep_test.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webcrypto/webcrypto.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('public API RSA-OAEP supports all backend hashes', (_) async {
+    final keyPair = await RsaOaepPrivateKey.generateKey(
+      2048,
+      BigInt.from(65537),
+      Hash.sha256,
+    );
+    final pkcs8 = await keyPair.privateKey.exportPkcs8Key();
+    final spki = await keyPair.publicKey.exportSpkiKey();
+    final plaintext = utf8.encode('Android JCA RSA-OAEP');
+    final label = utf8.encode('context');
+
+    for (final hash in <Hash>[
+      Hash.sha1,
+      Hash.sha256,
+      Hash.sha384,
+      Hash.sha512,
+    ]) {
+      final privateKey = await RsaOaepPrivateKey.importPkcs8Key(pkcs8, hash);
+      final publicKey = await RsaOaepPublicKey.importSpkiKey(spki, hash);
+      final ciphertext = await publicKey.encryptBytes(plaintext, label: label);
+
+      expect(
+        await privateKey.decryptBytes(ciphertext, label: label),
+        plaintext,
+      );
+      await expectLater(
+        privateKey.decryptBytes(ciphertext, label: utf8.encode('wrong')),
+        throwsA(isA<OperationError>()),
+      );
+    }
+  });
+}

--- a/lib/src/impl_jni/impl_jni.rsaoaep.dart
+++ b/lib/src/impl_jni/impl_jni.rsaoaep.dart
@@ -22,16 +22,28 @@ final class _StaticRsaOaepPrivateKeyImpl
   Future<RsaOaepPrivateKeyImpl> importPkcs8Key(
     List<int> keyData,
     HashImpl hash,
-  ) {
-    throw UnimplementedError('Not implemented');
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    return _RsaOaepPrivateKeyImpl(
+      _importPkcs8RsaPrivateKey(_asUint8List(keyData)),
+      h,
+    );
   }
 
   @override
   Future<RsaOaepPrivateKeyImpl> importJsonWebKey(
     Map<String, dynamic> jwk,
     HashImpl hash,
-  ) {
-    throw UnimplementedError('Not implemented');
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    return _RsaOaepPrivateKeyImpl(
+      _importJwkRsaPrivateKey(
+        jwk,
+        expectedAlg: h._rsaOaepJwkAlg,
+        expectedUse: 'enc',
+      ),
+      h,
+    );
   }
 
   @override
@@ -39,24 +51,169 @@ final class _StaticRsaOaepPrivateKeyImpl
     int modulusLength,
     BigInt publicExponent,
     HashImpl hash,
-  ) {
-    throw UnimplementedError('Not implemented');
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    final keyPair = await _generateRsaKeyPair(modulusLength, publicExponent);
+    return (
+      _RsaOaepPrivateKeyImpl(
+        _importPkcs8RsaPrivateKey(keyPair.privateKeyData),
+        h,
+      ),
+      _RsaOaepPublicKeyImpl(_importSpkiRsaPublicKey(keyPair.publicKeyData), h),
+    );
   }
+}
+
+final class _RsaOaepPrivateKeyImpl implements RsaOaepPrivateKeyImpl {
+  _RsaOaepPrivateKeyImpl(this._key, this._hash);
+
+  final _JcaKeyOwner _key;
+  final _HashImpl _hash;
+
+  @override
+  Future<Uint8List> decryptBytes(List<int> data, {List<int>? label}) {
+    return _rsaOaepEncryptDecrypt(
+      _key,
+      _hash,
+      _asUint8List(data),
+      label == null ? null : _asUint8List(label),
+      encrypt: false,
+    );
+  }
+
+  @override
+  Future<Uint8List> exportPkcs8Key() async =>
+      _exportEncodedRsaKey(_key, 'private');
+
+  @override
+  Future<Map<String, dynamic>> exportJsonWebKey() async =>
+      _exportJwkRsaPrivateKey(
+        _key,
+        jwkAlg: _hash._rsaOaepJwkAlg,
+        jwkUse: 'enc',
+      );
 }
 
 final class _StaticRsaOaepPublicKeyImpl implements StaticRsaOaepPublicKeyImpl {
   const _StaticRsaOaepPublicKeyImpl();
 
   @override
-  Future<RsaOaepPublicKeyImpl> importSpkiKey(List<int> keyData, HashImpl hash) {
-    throw UnimplementedError('Not implemented');
+  Future<RsaOaepPublicKeyImpl> importSpkiKey(
+    List<int> keyData,
+    HashImpl hash,
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    return _RsaOaepPublicKeyImpl(
+      _importSpkiRsaPublicKey(_asUint8List(keyData)),
+      h,
+    );
   }
 
   @override
   Future<RsaOaepPublicKeyImpl> importJsonWebKey(
     Map<String, dynamic> jwk,
     HashImpl hash,
-  ) {
-    throw UnimplementedError('Not implemented');
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    return _RsaOaepPublicKeyImpl(
+      _importJwkRsaPublicKey(
+        jwk,
+        expectedAlg: h._rsaOaepJwkAlg,
+        expectedUse: 'enc',
+      ),
+      h,
+    );
+  }
+}
+
+final class _RsaOaepPublicKeyImpl implements RsaOaepPublicKeyImpl {
+  _RsaOaepPublicKeyImpl(this._key, this._hash);
+
+  final _JcaKeyOwner _key;
+  final _HashImpl _hash;
+
+  @override
+  Future<Uint8List> encryptBytes(List<int> data, {List<int>? label}) {
+    return _rsaOaepEncryptDecrypt(
+      _key,
+      _hash,
+      _asUint8List(data),
+      label == null ? null : _asUint8List(label),
+      encrypt: true,
+    );
+  }
+
+  @override
+  Future<Uint8List> exportSpkiKey() async =>
+      _exportEncodedRsaKey(_key, 'public');
+
+  @override
+  Future<Map<String, dynamic>> exportJsonWebKey() async =>
+      _exportJwkRsaPublicKey(_key, jwkAlg: _hash._rsaOaepJwkAlg, jwkUse: 'enc');
+}
+
+Future<Uint8List> _rsaOaepEncryptDecrypt(
+  _JcaKeyOwner key,
+  _HashImpl hash,
+  Uint8List data,
+  Uint8List? label, {
+  required bool encrypt,
+}) async {
+  try {
+    return jni.using((arena) {
+      final transformation = 'RSA/ECB/OAEPPadding'.toJString()
+        ..releasedBy(arena);
+      final cipher = Cipher.getInstance(transformation);
+      if (cipher == null) {
+        throw AssertionError('JCA Cipher(RSA/ECB/OAEPPadding) returned null');
+      }
+      cipher.releasedBy(arena);
+
+      final hashName = hash._jcaName.toJString()..releasedBy(arena);
+      final mgfName = 'MGF1'.toJString()..releasedBy(arena);
+      final mgfParameters = MGF1ParameterSpec(hashName)..releasedBy(arena);
+      final labelBytes = arena.copyToJByteArray(label ?? Uint8List(0));
+      final pSource = PSource$PSpecified(labelBytes)..releasedBy(arena);
+      final parameters = OAEPParameterSpec(
+        hashName,
+        mgfName,
+        mgfParameters,
+        pSource,
+      )..releasedBy(arena);
+
+      final jcaKey = key.key.as(Key.type)..releasedBy(arena);
+      cipher.init$2(
+        encrypt ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE,
+        jcaKey,
+        parameters,
+      );
+
+      final input = arena.copyToJByteArray(data);
+      final output = cipher.doFinal$2(input);
+      if (output == null) {
+        throw AssertionError('JCA RSA-OAEP returned null');
+      }
+      output.releasedBy(arena);
+      return output.copyToDartBytes();
+    });
+  } on jni.JThrowable catch (e) {
+    throw _rsaOperationError(
+      e,
+      encrypt
+          ? 'JCA RSA-OAEP encryption failed'
+          : 'JCA RSA-OAEP decryption failed',
+    );
+  }
+}
+
+extension _RsaOaepHashMetadata on _HashImpl {
+  String get _rsaOaepJwkAlg {
+    return switch (_jcaName) {
+      'SHA-1' => 'RSA-OAEP',
+      'SHA-256' => 'RSA-OAEP-256',
+      'SHA-384' => 'RSA-OAEP-384',
+      'SHA-512' => 'RSA-OAEP-512',
+      _ => throw AssertionError('Unknown hash algorithm: $_jcaName'),
+    };
   }
 }

--- a/test/impl_jni_rsaoaep_test.dart
+++ b/test/impl_jni_rsaoaep_test.dart
@@ -1,0 +1,107 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:webcrypto/src/impl_ffi/impl_ffi.dart' as ffi_impl;
+import 'package:webcrypto/src/impl_interface/impl_interface.dart';
+import 'package:webcrypto/src/impl_jni/impl_jni.dart' as jni_impl;
+
+import 'src/jni_test_setup.dart'
+    if (dart.library.io) 'src/jni_test_setup_io.dart';
+
+void main() {
+  final skipReason = jniHelperSetupSkipReason;
+  late RsaOaepPrivateKeyImpl privateKey;
+  late RsaOaepPublicKeyImpl publicKey;
+
+  setUpAll(() async {
+    if (skipReason != null) {
+      return;
+    }
+
+    spawnJniForDesktopTests();
+    final keyPair = await jni_impl.webCryptImpl.rsaOaepPrivateKey.generateKey(
+      2048,
+      BigInt.from(65537),
+      jni_impl.webCryptImpl.sha256,
+    );
+    privateKey = keyPair.$1;
+    publicKey = keyPair.$2;
+  });
+
+  test('JCA RSA-OAEP digest, MGF1, and label interoperate with FFI', () async {
+    final plaintext = Uint8List.fromList(utf8.encode('RSA-OAEP message'));
+    final label = Uint8List.fromList(utf8.encode('context label'));
+    final ffiPrivateKey = await ffi_impl.webCryptImpl.rsaOaepPrivateKey
+        .importPkcs8Key(
+          await privateKey.exportPkcs8Key(),
+          ffi_impl.webCryptImpl.sha256,
+        );
+    final ffiPublicKey = await ffi_impl.webCryptImpl.rsaOaepPublicKey
+        .importSpkiKey(
+          await publicKey.exportSpkiKey(),
+          ffi_impl.webCryptImpl.sha256,
+        );
+
+    final jcaCiphertext = await publicKey.encryptBytes(plaintext, label: label);
+    final ffiCiphertext = await ffiPublicKey.encryptBytes(
+      plaintext,
+      label: label,
+    );
+
+    expect(
+      await ffiPrivateKey.decryptBytes(jcaCiphertext, label: label),
+      plaintext,
+    );
+    expect(
+      await privateKey.decryptBytes(ffiCiphertext, label: label),
+      plaintext,
+    );
+  }, skip: skipReason);
+
+  test('JCA RSA-OAEP treats null and empty labels equivalently', () async {
+    final plaintext = Uint8List.fromList(utf8.encode('empty label'));
+    final ciphertext = await publicKey.encryptBytes(plaintext);
+
+    expect(
+      await privateKey.decryptBytes(ciphertext, label: Uint8List(0)),
+      plaintext,
+    );
+  }, skip: skipReason);
+
+  test('JCA RSA-OAEP translates attacker-controlled failures', () async {
+    final plaintext = Uint8List.fromList(utf8.encode('message'));
+    final ciphertext = await publicKey.encryptBytes(
+      plaintext,
+      label: utf8.encode('expected'),
+    );
+
+    await expectLater(
+      privateKey.decryptBytes(ciphertext, label: utf8.encode('wrong')),
+      throwsA(isA<OperationError>()),
+    );
+
+    // A 2048-bit RSA key with SHA-256 accepts at most 190 plaintext bytes.
+    await expectLater(
+      publicKey.encryptBytes(Uint8List(191)),
+      throwsA(isA<OperationError>()),
+    );
+  }, skip: skipReason);
+}


### PR DESCRIPTION
## Summary

Adds the JNI/JCA RSA-OAEP implementation on top of the Android JCA backend and the persistent RSA key ownership introduced in #323.

This PR implements:
- RSA key generation with public exponents 3 and 65537
- PKCS#8 private-key and SPKI public-key import/export
- RSA-OAEP JWK import/export with canonical `RSA-OAEP` metadata for SHA-1
- byte encryption and decryption with optional labels
- explicit OAEP digest, MGF1 digest, and label parameters
- provider-error translation for invalid ciphertext, incorrect labels, and unsupported plaintext sizes
- focused desktop JNI interoperability tests and an Android smoke test covering all supported hashes

Persistent JCA keys are retained through the shared isolate-unsendable key owner. JNI arenas are used only for temporary values created by an operation.

Canonical SHA-1 export and historical `RSA-OAEP-1` import compatibility were established in #337. 

## Testing

Desktop JNI setup, if it has not been run already:
```sh
dart run jni:setup
```

Verified:
```sh
dart format --output=none --set-exit-if-changed .
dart analyze
dart test test/impl_jni_rsaoaep_test.dart
dart test test/webcrypto_test.dart -p vm -n RSA-OAEP
cd example/webcrypto_demo_flutter_app
flutter test integration_test/jni_rsaoaep_test.dart -d emulator-name
git diff --check
```
