### PR TITLE
feat(impl_jni): add JCA RSA-PSS implementation

### DIFF
--- a/example/webcrypto_demo_flutter_app/README.md
+++ b/example/webcrypto_demo_flutter_app/README.md
@@ -53,3 +53,10 @@ To run the Android JNI/JCA RSA-OAEP smoke test:
 flutter test integration_test/jni_rsaoaep_test.dart \
   -d emulator-name
 ```
+
+To run the Android JNI/JCA RSA-PSS smoke test:
+
+```sh
+flutter test integration_test/jni_rsapss_test.dart \
+  -d emulator-name
+```

--- a/example/webcrypto_demo_flutter_app/integration_test/jni_rsapss_test.dart
+++ b/example/webcrypto_demo_flutter_app/integration_test/jni_rsapss_test.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webcrypto/webcrypto.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('public API RSA-PSS supports all backend hashes', (_) async {
+    final keyPair = await RsaPssPrivateKey.generateKey(
+      2048,
+      BigInt.from(65537),
+      Hash.sha256,
+    );
+    final pkcs8 = await keyPair.privateKey.exportPkcs8Key();
+    final spki = await keyPair.publicKey.exportSpkiKey();
+    final data = utf8.encode('Android JCA RSA-PSS');
+    final modified = Uint8List.fromList(data)..[0] ^= 0x01;
+
+    for (final (hash, saltLength) in <(Hash, int)>[
+      (Hash.sha1, 20),
+      (Hash.sha256, 32),
+      (Hash.sha384, 48),
+      (Hash.sha512, 64),
+    ]) {
+      final privateKey = await RsaPssPrivateKey.importPkcs8Key(pkcs8, hash);
+      final publicKey = await RsaPssPublicKey.importSpkiKey(spki, hash);
+      final signature = await privateKey.signBytes(data, saltLength);
+
+      expect(await publicKey.verifyBytes(signature, data, saltLength), isTrue);
+      expect(
+        await publicKey.verifyBytes(signature, modified, saltLength),
+        isFalse,
+      );
+    }
+  });
+}

--- a/lib/src/impl_jni/impl_jni.rsapss.dart
+++ b/lib/src/impl_jni/impl_jni.rsapss.dart
@@ -244,6 +244,12 @@ Signature _createRsaPssSignature(
   return signature;
 }
 
+// TODO: Decide the RSA-PSS policy for Android API 21-22. Android only
+// guarantees the hash-specific SHAxxxwithRSA/PSS aliases from API 23, while
+// RSASSA-PSS availability depends on the installed provider. Possible policies
+// include documenting provider-dependent support, requiring API 23, or routing
+// unsupported cases to another backend. See:
+// https://developer.android.com/reference/java/security/Signature
 Signature _getRsaPssSignature(jni.Arena arena, _HashImpl hash) {
   try {
     return _getRsaPssSignatureByName(arena, 'RSASSA-PSS');

--- a/lib/src/impl_jni/impl_jni.rsapss.dart
+++ b/lib/src/impl_jni/impl_jni.rsapss.dart
@@ -270,7 +270,7 @@ void _validateRsaPssSaltLength(int saltLength) {
     throw ArgumentError.value(
       saltLength,
       'saltLength',
-      'must be a positive integer',
+      'must be a non-negative integer',
     );
   }
 }

--- a/lib/src/impl_jni/impl_jni.rsapss.dart
+++ b/lib/src/impl_jni/impl_jni.rsapss.dart
@@ -21,32 +21,278 @@ final class _StaticRsaPssPrivateKeyImpl implements StaticRsaPssPrivateKeyImpl {
   Future<RsaPssPrivateKeyImpl> importPkcs8Key(
     List<int> keyData,
     HashImpl hash,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    return _RsaPssPrivateKeyImpl(
+      _importPkcs8RsaPrivateKey(_asUint8List(keyData)),
+      h,
+    );
+  }
 
   @override
   Future<RsaPssPrivateKeyImpl> importJsonWebKey(
     Map<String, dynamic> jwk,
     HashImpl hash,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    return _RsaPssPrivateKeyImpl(
+      _importJwkRsaPrivateKey(
+        jwk,
+        expectedAlg: h._rsaPssJwkAlg,
+        expectedUse: 'sig',
+      ),
+      h,
+    );
+  }
 
   @override
   Future<(RsaPssPrivateKeyImpl, RsaPssPublicKeyImpl)> generateKey(
     int modulusLength,
     BigInt publicExponent,
     HashImpl hash,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    final keyPair = await _generateRsaKeyPair(modulusLength, publicExponent);
+    return (
+      _RsaPssPrivateKeyImpl(
+        _importPkcs8RsaPrivateKey(keyPair.privateKeyData),
+        h,
+      ),
+      _RsaPssPublicKeyImpl(_importSpkiRsaPublicKey(keyPair.publicKeyData), h),
+    );
+  }
+}
+
+final class _RsaPssPrivateKeyImpl implements RsaPssPrivateKeyImpl {
+  _RsaPssPrivateKeyImpl(this._key, this._hash);
+
+  final _JcaKeyOwner _key;
+  final _HashImpl _hash;
+
+  @override
+  Future<Uint8List> signBytes(List<int> data, int saltLength) {
+    return signStream(Stream.value(data), saltLength);
+  }
+
+  @override
+  Future<Uint8List> signStream(Stream<List<int>> data, int saltLength) {
+    _validateRsaPssSaltLength(saltLength);
+    return _signRsaPssStream(_key, _hash, data, saltLength);
+  }
+
+  @override
+  Future<Uint8List> exportPkcs8Key() async =>
+      _exportEncodedRsaKey(_key, 'private');
+
+  @override
+  Future<Map<String, dynamic>> exportJsonWebKey() async =>
+      _exportJwkRsaPrivateKey(_key, jwkAlg: _hash._rsaPssJwkAlg, jwkUse: 'sig');
 }
 
 final class _StaticRsaPssPublicKeyImpl implements StaticRsaPssPublicKeyImpl {
   const _StaticRsaPssPublicKeyImpl();
 
   @override
-  Future<RsaPssPublicKeyImpl> importSpkiKey(List<int> keyData, HashImpl hash) =>
-      throw UnimplementedError('Not implemented');
+  Future<RsaPssPublicKeyImpl> importSpkiKey(
+    List<int> keyData,
+    HashImpl hash,
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    return _RsaPssPublicKeyImpl(
+      _importSpkiRsaPublicKey(_asUint8List(keyData)),
+      h,
+    );
+  }
 
   @override
   Future<RsaPssPublicKeyImpl> importJsonWebKey(
     Map<String, dynamic> jwk,
     HashImpl hash,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    final h = _rsaHashFromHash(hash);
+    return _RsaPssPublicKeyImpl(
+      _importJwkRsaPublicKey(
+        jwk,
+        expectedAlg: h._rsaPssJwkAlg,
+        expectedUse: 'sig',
+      ),
+      h,
+    );
+  }
+}
+
+final class _RsaPssPublicKeyImpl implements RsaPssPublicKeyImpl {
+  _RsaPssPublicKeyImpl(this._key, this._hash);
+
+  final _JcaKeyOwner _key;
+  final _HashImpl _hash;
+
+  @override
+  Future<bool> verifyBytes(
+    List<int> signature,
+    List<int> data,
+    int saltLength,
+  ) {
+    return verifyStream(signature, Stream.value(data), saltLength);
+  }
+
+  @override
+  Future<bool> verifyStream(
+    List<int> signature,
+    Stream<List<int>> data,
+    int saltLength,
+  ) {
+    _validateRsaPssSaltLength(saltLength);
+    return _verifyRsaPssStream(
+      _key,
+      _hash,
+      _asUint8List(signature),
+      data,
+      saltLength,
+    );
+  }
+
+  @override
+  Future<Uint8List> exportSpkiKey() async =>
+      _exportEncodedRsaKey(_key, 'public');
+
+  @override
+  Future<Map<String, dynamic>> exportJsonWebKey() async =>
+      _exportJwkRsaPublicKey(_key, jwkAlg: _hash._rsaPssJwkAlg, jwkUse: 'sig');
+}
+
+Future<Uint8List> _signRsaPssStream(
+  _JcaKeyOwner key,
+  _HashImpl hash,
+  Stream<List<int>> data,
+  int saltLength,
+) async {
+  final arena = jni.Arena();
+  try {
+    final signature = _createRsaPssSignature(arena, hash, saltLength);
+    signature.initSign(key.key);
+
+    final buffer = jni.JByteArray(_defaultChunkSize)..releasedBy(arena);
+    await for (final chunk in data) {
+      _updateRsaSignature(signature, buffer, chunk);
+    }
+
+    final result = signature.sign();
+    if (result == null) {
+      throw AssertionError('JCA RSA-PSS returned null');
+    }
+    result.releasedBy(arena);
+    return result.copyToDartBytes();
+  } on jni.JThrowable catch (e) {
+    throw _rsaOperationError(e, 'JCA RSA-PSS signing failed');
+  } finally {
+    arena.releaseAll();
+  }
+}
+
+Future<bool> _verifyRsaPssStream(
+  _JcaKeyOwner key,
+  _HashImpl hash,
+  Uint8List suppliedSignature,
+  Stream<List<int>> data,
+  int saltLength,
+) async {
+  final arena = jni.Arena();
+  try {
+    final verifier = _createRsaPssSignature(arena, hash, saltLength);
+    verifier.initVerify(key.key);
+
+    final buffer = jni.JByteArray(_defaultChunkSize)..releasedBy(arena);
+    await for (final chunk in data) {
+      _updateRsaSignature(verifier, buffer, chunk);
+    }
+
+    final javaSignature = arena.copyToJByteArray(suppliedSignature);
+    try {
+      return verifier.verify(javaSignature);
+    } on jni.JThrowable catch (e) {
+      // Invalid signature encodings are verification failures, not operation
+      // failures. Release the attacker-triggerable Java throwable promptly.
+      e.release();
+      return false;
+    }
+  } on jni.JThrowable catch (e) {
+    throw _rsaOperationError(e, 'JCA RSA-PSS verification failed');
+  } finally {
+    arena.releaseAll();
+  }
+}
+
+Signature _createRsaPssSignature(
+  jni.Arena arena,
+  _HashImpl hash,
+  int saltLength,
+) {
+  final signature = _getRsaPssSignature(arena, hash);
+
+  final hashName = hash._jcaName.toJString()..releasedBy(arena);
+  final mgfName = 'MGF1'.toJString()..releasedBy(arena);
+  final mgfParameters = MGF1ParameterSpec(hashName)..releasedBy(arena);
+  final parameters = PSSParameterSpec(
+    hashName,
+    mgfName,
+    mgfParameters,
+    saltLength,
+    1,
+  )..releasedBy(arena);
+  signature.parameter = parameters;
+  return signature;
+}
+
+Signature _getRsaPssSignature(jni.Arena arena, _HashImpl hash) {
+  try {
+    return _getRsaPssSignatureByName(arena, 'RSASSA-PSS');
+  } on jni.JThrowable catch (e) {
+    // Some Android providers expose hash-specific PSS names, while desktop
+    // JCA providers commonly expose the standard parameterized name.
+    e.release();
+    return _getRsaPssSignatureByName(arena, hash._rsaPssJcaName);
+  }
+}
+
+Signature _getRsaPssSignatureByName(jni.Arena arena, String name) {
+  final algorithm = name.toJString()..releasedBy(arena);
+  final signature = Signature.getInstance(algorithm);
+  if (signature == null) {
+    throw AssertionError('JCA Signature($name) returned null');
+  }
+  signature.releasedBy(arena);
+  return signature;
+}
+
+void _validateRsaPssSaltLength(int saltLength) {
+  if (saltLength < 0) {
+    throw ArgumentError.value(
+      saltLength,
+      'saltLength',
+      'must be a positive integer',
+    );
+  }
+}
+
+extension _RsaPssHashMetadata on _HashImpl {
+  String get _rsaPssJcaName {
+    return switch (_jcaName) {
+      'SHA-1' => 'SHA1withRSA/PSS',
+      'SHA-256' => 'SHA256withRSA/PSS',
+      'SHA-384' => 'SHA384withRSA/PSS',
+      'SHA-512' => 'SHA512withRSA/PSS',
+      _ => throw AssertionError('Unknown hash algorithm: $_jcaName'),
+    };
+  }
+
+  String get _rsaPssJwkAlg {
+    return switch (_jcaName) {
+      'SHA-1' => 'PS1',
+      'SHA-256' => 'PS256',
+      'SHA-384' => 'PS384',
+      'SHA-512' => 'PS512',
+      _ => throw AssertionError('Unknown hash algorithm: $_jcaName'),
+    };
+  }
 }

--- a/test/impl_jni_rsapss_test.dart
+++ b/test/impl_jni_rsapss_test.dart
@@ -1,0 +1,122 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:webcrypto/src/impl_ffi/impl_ffi.dart' as ffi_impl;
+import 'package:webcrypto/src/impl_interface/impl_interface.dart';
+import 'package:webcrypto/src/impl_jni/impl_jni.dart' as jni_impl;
+
+import 'src/jni_test_setup.dart'
+    if (dart.library.io) 'src/jni_test_setup_io.dart';
+
+void main() {
+  final skipReason = jniHelperSetupSkipReason;
+  late RsaPssPrivateKeyImpl privateKey;
+  late RsaPssPublicKeyImpl publicKey;
+
+  setUpAll(() async {
+    if (skipReason != null) {
+      return;
+    }
+
+    spawnJniForDesktopTests();
+    final keyPair = await jni_impl.webCryptImpl.rsaPssPrivateKey.generateKey(
+      2048,
+      BigInt.from(65537),
+      jni_impl.webCryptImpl.sha256,
+    );
+    privateKey = keyPair.$1;
+    publicKey = keyPair.$2;
+  });
+
+  test('JCA RSA-PSS parameters and streams interoperate with FFI', () async {
+    const saltLength = 20;
+    final chunks = <Uint8List>[
+      Uint8List.fromList(List<int>.generate(9000, (i) => i & 0xff)),
+      Uint8List.fromList(utf8.encode('RSA-PSS interoperability')),
+    ];
+    final ffiPrivateKey = await ffi_impl.webCryptImpl.rsaPssPrivateKey
+        .importPkcs8Key(
+          await privateKey.exportPkcs8Key(),
+          ffi_impl.webCryptImpl.sha256,
+        );
+    final ffiPublicKey = await ffi_impl.webCryptImpl.rsaPssPublicKey
+        .importSpkiKey(
+          await publicKey.exportSpkiKey(),
+          ffi_impl.webCryptImpl.sha256,
+        );
+
+    final jcaSignature = await privateKey.signStream(
+      Stream.fromIterable(chunks),
+      saltLength,
+    );
+    final ffiSignature = await ffiPrivateKey.signStream(
+      Stream.fromIterable(chunks),
+      saltLength,
+    );
+
+    expect(
+      await ffiPublicKey.verifyStream(
+        jcaSignature,
+        Stream.fromIterable(chunks),
+        saltLength,
+      ),
+      isTrue,
+    );
+    expect(
+      await publicKey.verifyStream(
+        ffiSignature,
+        Stream.fromIterable(chunks),
+        saltLength,
+      ),
+      isTrue,
+    );
+  }, skip: skipReason);
+
+  test('JCA RSA-PSS treats malformed signatures as invalid', () async {
+    final data = utf8.encode('message');
+    final signature = await privateKey.signBytes(data, 32);
+    final modified = Uint8List.fromList(signature)..[0] ^= 0x01;
+
+    expect(await publicKey.verifyBytes(modified, data, 32), isFalse);
+    expect(
+      await publicKey.verifyBytes(
+        Uint8List.sublistView(signature, 1),
+        data,
+        32,
+      ),
+      isFalse,
+    );
+  }, skip: skipReason);
+
+  test('JCA RSA-PSS validates and translates invalid salt lengths', () async {
+    final data = utf8.encode('message');
+
+    expect(() => privateKey.signBytes(data, -1), throwsArgumentError);
+    expect(
+      () => publicKey.verifyBytes(Uint8List(256), data, -1),
+      throwsArgumentError,
+    );
+    await expectLater(
+      privateKey.signBytes(data, 512),
+      throwsA(isA<OperationError>()),
+    );
+  }, skip: skipReason);
+}


### PR DESCRIPTION
## Summary

Adds the JNI/JCA RSA-PSS implementation on top of the Android JCA backend and the persistent RSA key ownership introduced in #323.

This PR implements:
- RSA key generation with public exponents 3 and 65537
- PKCS#8 private-key and SPKI public-key import/export
- RSA-PSS JWK import/export
- byte and stream signing and verification
- explicit digest, MGF1 digest, salt-length, and trailer-field parameters
- standard `RSASSA-PSS` provider lookup with hash-specific Android aliases
- focused desktop JNI tests and an Android smoke test covering all supported hashes

Persistent JCA keys are retained through the shared isolate-unsendable key
owner. JNI arenas are used only for temporary values created by an operation.

## Testing

Desktop JNI setup, if it has not been run already:
```sh
dart run jni:setup
```

Verified:
```sh
dart format --output=none --set-exit-if-changed .
dart analyze
dart test test/impl_jni_rsapss_test.dart
dart test test/webcrypto_test.dart -p vm -n RSA-PSS
cd example/webcrypto_demo_flutter_app
flutter test integration_test/jni_rsapss_test.dart -d emulator-name
git diff --check
```