### PR TITLE
docs: move PBKDF2 example to a separate file (#283)

### DIFF
--- a/example/webcrypto/pbkdf2/derive_bits.dart
+++ b/example/webcrypto/pbkdf2/derive_bits.dart
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ignore_for_file: avoid_print
+
+// #region example
+import 'dart:convert' show utf8, base64;
+
+import 'package:webcrypto/webcrypto.dart';
+
+Future<void> main() async {
+  // Provide a password to be used for key derivation.
+  final key = await Pbkdf2SecretKey.importRawKey(
+    utf8.encode('my-password-in-plain-text'),
+  );
+
+  // Derive a key from the password.
+  final derivedKey = await key.deriveBits(
+    256, // number of bits to derive.
+    Hash.sha256,
+    utf8.encode('unique salt'),
+    100000,
+  );
+
+  // Print the derived key. This could also be used as the basis for other
+  // new symmetric cryptographic keys.
+  print(base64.encode(derivedKey));
+}
+
+// #endregion

--- a/lib/src/webcrypto/webcrypto.pbkdf2.dart
+++ b/lib/src/webcrypto/webcrypto.pbkdf2.dart
@@ -25,27 +25,7 @@ part of 'webcrypto.dart';
 ///
 /// {@template Pbkdf2SecretKey:example}
 /// **Example**
-/// ```
-/// import 'dart:convert' show utf8, base64;
-/// import 'package:webcrypto/webcrypto.dart';
-///
-/// // Provide a password to be used for key derivation
-/// final key = await Pbkdf2SecretKey.importRawKey(utf8.decode(
-///   'my-password-in-plain-text',
-/// ));
-///
-/// // Derive a key from password
-/// final derivedKey = await Pbkdf2SecretKey.deriveBits(
-///   256, // number of bits to derive.
-///   Hash.sha256,
-///   utf8.decode('unique salt'),
-///   100000,
-/// );
-///
-/// // Print the derived key, this could also be used as basis for other new
-/// // symmetric cryptographic keys.
-/// print(base64.encode(derivedKey));
-/// ```
+/// {@example /example/webcrypto/pbkdf2/derive_bits.dart#example}
 /// {@endtemplate}
 ///
 /// [1]: https://www.rfc-editor.org/rfc/rfc8018


### PR DESCRIPTION
Part of #283, one primitive per PR. Moves the `Pbkdf2SecretKey` example out of the doc comment into `example/webcrypto/pbkdf2/derive_bits.dart` and references it with `{@example}`, same as the HMAC one.

Moving it to a real file surfaced a couple of bugs in the example that I fixed so it actually analyzes and runs:
- `utf8.decode(...)` on the password and salt should be `utf8.encode(...)` (string to bytes, not the other way around)
- `deriveBits` is an instance method, so it's now called on the imported `key` instead of statically on `Pbkdf2SecretKey`

`dart analyze` and `dart format` both pass on the new file.