### PR TITLE
fix(hkdf): validate output length before allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.6.2-wip
 * Fixed JS interop to enable WebAssembly.
 * Fixed native RSA public-key JWK imports to reject private key material.
+* Fixed native HKDF output-length validation to reject oversized requests
+  before allocating memory.
 
 # 0.6.1
 * Added Dart native build hooks and native asset lookup for the bundled

--- a/lib/src/impl_ffi/impl_ffi.hkdf.dart
+++ b/lib/src/impl_ffi/impl_ffi.hkdf.dart
@@ -57,6 +57,12 @@ final class _HkdfSecretKeyImpl implements HkdfSecretKeyImpl {
     }
 
     final lengthInBytes = length ~/ 8;
+    const lengthTooLong =
+        'Length specified for HkdfSecretKey.deriveBits is too long';
+    final maxLengthInBytes = 255 * ssl.EVP_MD_size(md);
+    if (lengthInBytes > maxLengthInBytes) {
+      throw operationError(lengthTooLong);
+    }
 
     return _Scope.async((scope) async {
       final out = scope<ffi.Uint8>(lengthInBytes);
@@ -76,9 +82,7 @@ final class _HkdfSecretKeyImpl implements HkdfSecretKeyImpl {
         if (ERR_GET_LIB(packed_error) == ERR_LIB_HKDF &&
             ERR_GET_REASON(packed_error) == HKDF_R_OUTPUT_TOO_LARGE) {
           ssl.ERR_clear_error();
-          throw operationError(
-            'Length specified for HkdfSecretKey.deriveBits is too long',
-          );
+          throw operationError(lengthTooLong);
         }
         _checkOpIsOne(r, fallback: 'HKDF key derivation failed');
       }

--- a/test/hkdf_output_length_test.dart
+++ b/test/hkdf_output_length_test.dart
@@ -1,0 +1,79 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'package:test/test.dart';
+import 'package:webcrypto/webcrypto.dart';
+
+const _lengthTooLong =
+    'Length specified for HkdfSecretKey.deriveBits is too long';
+
+void main() {
+  late HkdfSecretKey key;
+
+  setUpAll(() async {
+    key = await HkdfSecretKey.importRawKey(const [1, 2, 3, 4]);
+  });
+
+  for (final (name, hash, hashLengthInBytes) in [
+    ('SHA-1', Hash.sha1, 20),
+    ('SHA-256', Hash.sha256, 32),
+    ('SHA-384', Hash.sha384, 48),
+    ('SHA-512', Hash.sha512, 64),
+  ]) {
+    final maxLengthInBytes = 255 * hashLengthInBytes;
+
+    test('$name accepts the RFC 5869 maximum output length', () async {
+      final derived = await key.deriveBits(
+        maxLengthInBytes * 8,
+        hash,
+        const [],
+        const [],
+      );
+
+      expect(derived, hasLength(maxLengthInBytes));
+    });
+
+    test('$name rejects output one byte beyond the maximum', () async {
+      await expectLater(
+        key.deriveBits((maxLengthInBytes + 1) * 8, hash, const [], const []),
+        throwsA(
+          isA<OperationError>().having(
+            (error) => error.toString(),
+            'message',
+            _lengthTooLong,
+          ),
+        ),
+      );
+    });
+  }
+
+  test(
+    'rejects a huge output length before allocating native memory',
+    () async {
+      await expectLater(
+        key.deriveBits(9223372036854775800, Hash.sha256, const [], const []),
+        throwsA(
+          isA<OperationError>().having(
+            (error) => error.toString(),
+            'message',
+            _lengthTooLong,
+          ),
+        ),
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- validate the RFC 5869 HKDF output limit before allocating the native output buffer
- preserve BoringSSL's output-too-large handling as a defensive fallback
- cover the exact limit and the first invalid length for every supported hash
- verify that a very large length is rejected without reaching native allocation

## Root cause

The FFI implementation allocated `length ~/ 8` bytes before calling BoringSSL. BoringSSL enforces HKDF's `255 * HashLen` maximum, but an extremely large request could fail during allocation before reaching that validation.

The implementation now derives the maximum from `EVP_MD_size` and rejects oversized output lengths before entering the allocation scope.

## Validation

- `dart format --output none --set-exit-if-changed lib/src/impl_ffi/impl_ffi.hkdf.dart test/hkdf_output_length_test.dart`
- `dart analyze --fatal-warnings .`
- `dart test test/hkdf_output_length_test.dart`
- `dart test -p vm --exclude-tags browser-interop`

Fixes #349
