### PR TITLE
test(ecdh): enable P-521 tests on Safari

### DIFF
--- a/lib/src/impl_interface/impl_interface.dart
+++ b/lib/src/impl_interface/impl_interface.dart
@@ -40,17 +40,7 @@ typedef KeyPair<T, S> = ({T privateKey, S publicKey});
 ///
 /// > [!NOTE]
 /// > Additional values may be added to this enum in the future.
-enum EllipticCurve {
-  p256,
-  p384,
-
-  ///
-  ///
-  /// P-521 is **not supported on Safari**, see [bug 216755 (bugs.webkit.org)][1].
-  ///
-  /// [1]: https://bugs.webkit.org/show_bug.cgi?id=216755
-  p521,
-}
+enum EllipticCurve { p256, p384, p521 }
 
 /// Thrown when an operation failed for an operation-specific reason.
 final class OperationError extends Error {

--- a/lib/src/testing/webcrypto/ecdh.dart
+++ b/lib/src/testing/webcrypto/ecdh.dart
@@ -15,7 +15,6 @@
 import 'package:webcrypto/webcrypto.dart';
 import '../utils/utils.dart';
 import '../utils/testrunner.dart';
-import '../utils/detected_runtime.dart';
 
 final runner = TestRunner.asymmetric<EcdhPrivateKey, EcdhPublicKey>(
   algorithm: 'ECDH',
@@ -170,9 +169,7 @@ final _testData = [
     "deriveParams": {},
   },
 
-  /// Safari and WebKit on Mac (with CommonCrypto) does not support P-521, see:
-  /// https://bugs.webkit.org/show_bug.cgi?id=216755
-  ...(nullOnSafari(_testDataWithP521) ?? <Map>[]),
+  ..._testDataWithP521,
 
   // TODO: generate on firefox, once the import/export pkcs8 has been figured out
 ];


### PR DESCRIPTION
## Summary

- enable the existing P-521 ECDH vectors when the test suite runs on Safari
- remove the obsolete documentation claiming that Safari does not support P-521
- remove the runtime-detection import that is no longer needed by the ECDH tests

Safari now supports P-521, so excluding these vectors leaves a supported path untested. The existing vectors already cover key import and export across raw, SPKI, PKCS8, and JWK formats, as well as 528-bit key derivation.

Closes #129.

## Validation

- `dart analyze --fatal-warnings .`
- full VM test suite (1,448 passed; 1 platform-specific skip)
- P-521 ECDH tests on Safari 26.5.2 with Dart2JS (41 passed)
- P-521 ECDH tests on Chrome with Dart2JS and Dart2Wasm (82 passed)
