### PR TITLE
docs: move fillRandomBytes example to a separate file

### DIFF
--- a/example/webcrypto/random/fill_random_bytes.dart
+++ b/example/webcrypto/random/fill_random_bytes.dart
@@ -1,0 +1,34 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ignore_for_file: avoid_print
+
+// #region example
+import 'dart:convert' show base64;
+import 'dart:typed_data' show Uint8List;
+
+import 'package:webcrypto/webcrypto.dart';
+
+void main() {
+  // Allocate a byte array of 64 bytes.
+  final bytes = Uint8List(64);
+
+  // Fill with random bytes.
+  fillRandomBytes(bytes);
+
+  // Print base64 encoded random bytes.
+  print(base64.encode(bytes));
+}
+
+// #endregion

--- a/lib/src/webcrypto/webcrypto.random.dart
+++ b/lib/src/webcrypto/webcrypto.random.dart
@@ -20,22 +20,7 @@ part of 'webcrypto.dart';
 /// calls to obtain more random bytes.
 ///
 /// **Example**
-/// ```dart
-/// import 'dart:convert' show base64;
-/// import 'dart:typed_data' show Uint8List;
-/// import 'package:webcrypto/webcrypto.dart';
-///
-/// void main() {
-///   // Allocate a byte array of 64 bytes.
-///   final bytes = Uint8List(64);
-///
-///   // Fill with random bytes.
-///   fillRandomBytes(bytes);
-///
-///   // Print base64 encoded random bytes.
-///   print(base64.encode(bytes));
-/// }
-/// ```
+/// {@example /example/webcrypto/random/fill_random_bytes.dart#example}
 void fillRandomBytes(
   TypedData destination,
   // Note: Uint8List and friends all implement TypedData, but dartdoc has a bug


### PR DESCRIPTION
Towards #283 — one primitive per PR, as requested in the issue.

Moves the `fillRandomBytes` example out of its dartdoc comment and into `example/webcrypto/random/fill_random_bytes.dart`, referenced with `{@example /example/webcrypto/random/fill_random_bytes.dart#example}`. This follows the shape of #293 (HMAC `importRawKey`).

**The example code itself is unchanged** from what the docs already showed — it was copied verbatim. The only additions are the license header, the `#region`/`#endregion` markers, and one `ignore_for_file`.

### Note on `avoid_print`

The example prints its result, and `example/webcrypto/` is not excluded from analysis, so `flutter_lints`' `avoid_print` fires on it once the code leaves the doc comment. I've added `// ignore_for_file: avoid_print` rather than change what the example demonstrates, since printing the random bytes is the point of it.

Happy to drop the `print` and the ignore instead if you'd prefer examples to be lint-clean without suppressions — that would mean the rendered docs differ slightly from today's.

### Verification

Run with Dart 3.12.2 (the repo requires `^3.10.0`):

- `dart analyze example/webcrypto lib` → **No issues found**
- `dart format --output=none --set-exit-if-changed` on both changed files → 0 changed
- Removed the `ignore_for_file` line temporarily to confirm the suppression is actually load-bearing → `avoid_print` fires, as expected
- Diffed the extracted example against the original doc comment → identical

---

AI disclosure: this change was drafted with AI assistance. I reviewed it, and the verification above (including the negative test for the lint suppression) was run locally before opening the PR.
