### PR TITLE
feat(impl_jni): add JCA HKDF implementation

### DIFF
--- a/example/webcrypto_demo_flutter_app/README.md
+++ b/example/webcrypto_demo_flutter_app/README.md
@@ -19,6 +19,13 @@ flutter test integration_test/jni_hmac_test.dart \
   -d emulator-name
 ```
 
+To run the Android JNI/JCA HKDF smoke test:
+
+```sh
+flutter test integration_test/jni_hkdf_test.dart \
+  -d emulator-name
+```
+
 To run the Android JNI/JCA AES-GCM smoke test:
 
 ```sh

--- a/example/webcrypto_demo_flutter_app/integration_test/jni_hkdf_test.dart
+++ b/example/webcrypto_demo_flutter_app/integration_test/jni_hkdf_test.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webcrypto/webcrypto.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('public API HKDF-SHA-256 matches RFC 5869', (_) async {
+    final key = await HkdfSecretKey.importRawKey(
+      Uint8List(22)..fillRange(0, 22, 0x0b),
+    );
+    final derived = await key.deriveBits(
+      42 * 8,
+      Hash.sha256,
+      Uint8List.fromList(List<int>.generate(13, (i) => i)),
+      Uint8List.fromList(List<int>.generate(10, (i) => 0xf0 + i)),
+    );
+
+    expect(
+      base64Encode(derived),
+      'PLJfJfqs1XqQQ09k0DYvKi0tCpDPGlpMXbAtVuzExb80AHII1biHGFhl',
+    );
+  });
+}

--- a/lib/src/impl_jni/impl_jni.hkdf.dart
+++ b/lib/src/impl_jni/impl_jni.hkdf.dart
@@ -18,6 +18,110 @@ final class _StaticHkdfSecretKeyImpl implements StaticHkdfSecretKeyImpl {
   const _StaticHkdfSecretKeyImpl();
 
   @override
-  Future<HkdfSecretKeyImpl> importRawKey(List<int> keyData) =>
-      throw UnimplementedError('Not implemented');
+  Future<HkdfSecretKeyImpl> importRawKey(List<int> keyData) async =>
+      _HkdfSecretKeyImpl(Uint8List.fromList(keyData));
+}
+
+final class _HkdfSecretKeyImpl implements HkdfSecretKeyImpl {
+  _HkdfSecretKeyImpl(this._keyData);
+
+  final Uint8List _keyData;
+
+  @override
+  Future<Uint8List> deriveBits(
+    int length,
+    HashImpl hash,
+    List<int> salt,
+    List<int> info,
+  ) async {
+    if (length < 0) {
+      throw ArgumentError.value(
+        length,
+        'length',
+        'must be a non-negative integer',
+      );
+    }
+    if (length % 8 != 0) {
+      throw operationError('The length for HKDF must be a multiple of 8 bits');
+    }
+
+    final h = _hmacHashFromHash(hash);
+    final lengthInBytes = length ~/ 8;
+
+    try {
+      return jni.using((arena) {
+        final algorithm = h._hmacJcaName.toJString()..releasedBy(arena);
+        final mac = Mac.getInstance(algorithm);
+        if (mac == null) {
+          throw AssertionError('JCA Mac(${h._hmacJcaName}) returned null');
+        }
+        mac.releasedBy(arena);
+
+        final hashLength = mac.macLength;
+        if (lengthInBytes > 255 * hashLength) {
+          throw operationError(
+            'Length specified for HkdfSecretKey.deriveBits is too long',
+          );
+        }
+        if (lengthInBytes == 0) {
+          return Uint8List(0);
+        }
+
+        // RFC 5869 defines an omitted salt as HashLen zero bytes. JCA's
+        // SecretKeySpec rejects an empty key, so normalize an empty salt to
+        // that equivalent representation before HKDF-Extract.
+        final saltData = salt.isEmpty
+            ? Uint8List(hashLength)
+            : _asUint8List(salt);
+        final javaSalt = arena.copyToJByteArray(saltData);
+        final extractKey = SecretKeySpec(javaSalt, algorithm)
+          ..releasedBy(arena);
+        mac.init(extractKey);
+
+        final inputKeyMaterial = arena.copyToJByteArray(_keyData);
+        final pseudorandomKey = mac.doFinal$2(inputKeyMaterial);
+        if (pseudorandomKey == null) {
+          throw AssertionError('JCA HKDF-Extract returned null');
+        }
+        pseudorandomKey.releasedBy(arena);
+
+        final expandKey = SecretKeySpec(pseudorandomKey, algorithm)
+          ..releasedBy(arena);
+        mac.init(expandKey);
+
+        final javaInfo = arena.copyToJByteArray(_asUint8List(info));
+        final block = jni.JByteArray(hashLength)..releasedBy(arena);
+        final output = Uint8List(lengthInBytes);
+        final blockCount = (lengthInBytes + hashLength - 1) ~/ hashLength;
+
+        var outputOffset = 0;
+        for (var blockIndex = 1; blockIndex <= blockCount; blockIndex++) {
+          if (blockIndex > 1) {
+            mac.update$1(block);
+          }
+          if (info.isNotEmpty) {
+            mac.update$1(javaInfo);
+          }
+          mac.update(blockIndex);
+          mac.doFinal$1(block, 0);
+
+          final remaining = lengthInBytes - outputOffset;
+          final blockLength = math.min(hashLength, remaining);
+          block.copyRangeToDart(output, outputOffset, blockLength);
+          outputOffset += blockLength;
+        }
+        return output;
+      });
+    } on OperationError {
+      rethrow;
+    } on jni.JThrowable catch (e) {
+      late final String message;
+      try {
+        message = e.message;
+      } finally {
+        e.release();
+      }
+      throw operationError('JCA HKDF derivation failed: $message');
+    }
+  }
 }

--- a/test/impl_jni_hkdf_test.dart
+++ b/test/impl_jni_hkdf_test.dart
@@ -1,0 +1,114 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:webcrypto/webcrypto.dart' show OperationError;
+import 'package:webcrypto/src/impl_ffi/impl_ffi.dart' as ffi_impl;
+import 'package:webcrypto/src/impl_jni/impl_jni.dart' as jni_impl;
+
+import 'src/jni_test_setup.dart'
+    if (dart.library.io) 'src/jni_test_setup_io.dart';
+
+void main() {
+  final skipReason = jniHelperSetupSkipReason;
+
+  setUpAll(() {
+    if (skipReason == null) {
+      spawnJniForDesktopTests();
+    }
+  });
+
+  test('JCA HKDF-SHA-256 matches RFC 5869 test case 1', () async {
+    final key = await jni_impl.webCryptImpl.hkdfSecretKey.importRawKey(
+      Uint8List(22)..fillRange(0, 22, 0x0b),
+    );
+    final derived = await key.deriveBits(
+      42 * 8,
+      jni_impl.webCryptImpl.sha256,
+      Uint8List.fromList(List<int>.generate(13, (i) => i)),
+      Uint8List.fromList(List<int>.generate(10, (i) => 0xf0 + i)),
+    );
+
+    expect(
+      base64Encode(derived),
+      'PLJfJfqs1XqQQ09k0DYvKi0tCpDPGlpMXbAtVuzExb80AHII1biHGFhl',
+    );
+  }, skip: skipReason);
+
+  test('JCA HKDF matches FFI for every supported hash', () async {
+    final jniKey = await jni_impl.webCryptImpl.hkdfSecretKey.importRawKey(
+      Uint8List.fromList([0, 1, 2, 0x80, 0xff]),
+    );
+    final ffiKey = await ffi_impl.webCryptImpl.hkdfSecretKey.importRawKey(
+      Uint8List.fromList([0, 1, 2, 0x80, 0xff]),
+    );
+    final hashes = [
+      (jni_impl.webCryptImpl.sha1, ffi_impl.webCryptImpl.sha1),
+      (jni_impl.webCryptImpl.sha256, ffi_impl.webCryptImpl.sha256),
+      (jni_impl.webCryptImpl.sha384, ffi_impl.webCryptImpl.sha384),
+      (jni_impl.webCryptImpl.sha512, ffi_impl.webCryptImpl.sha512),
+    ];
+
+    for (final (jniHash, ffiHash) in hashes) {
+      final actual = await jniKey.deriveBits(512, jniHash, const [], const []);
+      final expected = await ffiKey.deriveBits(
+        512,
+        ffiHash,
+        const [],
+        const [],
+      );
+      expect(actual, expected);
+    }
+  }, skip: skipReason);
+
+  test('JCA HKDF validates output length', () async {
+    final jniKey = await jni_impl.webCryptImpl.hkdfSecretKey.importRawKey([1]);
+    final ffiKey = await ffi_impl.webCryptImpl.hkdfSecretKey.importRawKey([1]);
+
+    expect(
+      await jniKey.deriveBits(
+        255 * 32 * 8,
+        jni_impl.webCryptImpl.sha256,
+        const [],
+        const [],
+      ),
+      await ffiKey.deriveBits(
+        255 * 32 * 8,
+        ffi_impl.webCryptImpl.sha256,
+        const [],
+        const [],
+      ),
+    );
+
+    await expectLater(
+      jniKey.deriveBits(7, jni_impl.webCryptImpl.sha256, const [], const []),
+      throwsA(isA<OperationError>()),
+    );
+    await expectLater(
+      jniKey.deriveBits(
+        (255 * 32 + 1) * 8,
+        jni_impl.webCryptImpl.sha256,
+        const [],
+        const [],
+      ),
+      throwsA(isA<OperationError>()),
+    );
+  }, skip: skipReason);
+}


### PR DESCRIPTION
## Summary

Adds the JNI/JCA HKDF implementation on top of the Android JCA backend.

This PR implements:
- raw key import with a defensive copy of the input key material
- RFC 5869 Extract-and-Expand using JCA `Mac`
- SHA-1, SHA-256, SHA-384, and SHA-512
- RFC 5869 empty-salt normalization and zero-length output
- byte-aligned output-length validation and the 255-block HKDF limit
- reusable Java output buffering across expand blocks
- focused RFC/FFI interoperability tests and an Android public-API smoke test

Generated JCA bindings are not changed in this PR. The required `Mac` and
`SecretKeySpec` bindings are already present on `android-jca-branch`.

## Testing

Desktop JNI setup, if it has not been run already:

```sh
dart run jni:setup
```

Verified:

```sh
dart format --output=none --set-exit-if-changed .
dart analyze
dart test test/impl_jni_hkdf_test.dart
dart test test/webcrypto_test.dart -p vm -n HKDF
cd example/webcrypto_demo_flutter_app
flutter test integration_test/jni_hkdf_test.dart -d emulator-name
cd ../..
git diff --check
```