### PR TITLE
feat(impl_jni): add JCA PBKDF2 implementation

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,25 @@
+# PBKDF2 benchmark
+
+The PBKDF2 benchmark measures SHA-256 derivation of a 256-bit output at 1,000,
+10,000, and 100,000 iterations. It uses password and salt values containing
+bytes above `0x7f`, and the desktop benchmark verifies that JNI and FFI produce
+the same output before collecting timings.
+
+Set up desktop JNI and run the desktop JNI/FFI comparison from the package
+root:
+
+```sh
+dart run jni:setup
+dart run benchmark/impl_jni_pbkdf2_benchmark.dart
+```
+
+Run the JNI benchmark on Android from the example application:
+
+```sh
+cd example/webcrypto_demo_flutter_app
+flutter test integration_test/jni_pbkdf2_benchmark.dart -d emulator-name
+```
+
+Results are medians after warm-up. They measure the complete backend call,
+including isolate and JNI overhead, and are not suitable for comparing
+different devices without controlling their runtime and thermal state.

--- a/benchmark/impl_jni_pbkdf2_benchmark.dart
+++ b/benchmark/impl_jni_pbkdf2_benchmark.dart
@@ -1,0 +1,121 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:webcrypto/src/impl_ffi/impl_ffi.dart' as ffi_impl;
+import 'package:webcrypto/src/impl_jni/impl_jni.dart' as jni_impl;
+
+import '../test/src/jni_test_setup_io.dart';
+
+const _configurations = [
+  (iterations: 1000, samples: 11),
+  (iterations: 10000, samples: 11),
+  (iterations: 100000, samples: 7),
+];
+
+Future<void> main() async {
+  final setupError = jniHelperSetupSkipReason;
+  if (setupError != null) {
+    throw StateError(setupError);
+  }
+  spawnJniForDesktopTests();
+
+  final password = Uint8List.fromList([0, 1, 2, 0x80, 0xff]);
+  final salt = Uint8List.fromList([0xff, 0x80, 2, 1, 0]);
+  final jniKey = await jni_impl.webCryptImpl.pbkdf2SecretKey.importRawKey(
+    password,
+  );
+  final ffiKey = await ffi_impl.webCryptImpl.pbkdf2SecretKey.importRawKey(
+    password,
+  );
+
+  stdout.writeln('backend,iterations,samples,median_ms');
+  for (final configuration in _configurations) {
+    final iterations = configuration.iterations;
+    final expected = await ffiKey.deriveBits(
+      256,
+      ffi_impl.webCryptImpl.sha256,
+      salt,
+      iterations,
+    );
+    final actual = await jniKey.deriveBits(
+      256,
+      jni_impl.webCryptImpl.sha256,
+      salt,
+      iterations,
+    );
+    if (!_bytesEqual(actual, expected)) {
+      throw StateError('JNI and FFI results differ at $iterations iterations');
+    }
+
+    final ffiMedian = await _medianMilliseconds(() async {
+      await ffiKey.deriveBits(
+        256,
+        ffi_impl.webCryptImpl.sha256,
+        salt,
+        iterations,
+      );
+    }, samples: configuration.samples);
+    final jniMedian = await _medianMilliseconds(() async {
+      await jniKey.deriveBits(
+        256,
+        jni_impl.webCryptImpl.sha256,
+        salt,
+        iterations,
+      );
+    }, samples: configuration.samples);
+
+    stdout.writeln(
+      'ffi,$iterations,${configuration.samples},'
+      '${ffiMedian.toStringAsFixed(2)}',
+    );
+    stdout.writeln(
+      'jni,$iterations,${configuration.samples},'
+      '${jniMedian.toStringAsFixed(2)}',
+    );
+  }
+}
+
+Future<double> _medianMilliseconds(
+  Future<void> Function() operation, {
+  required int samples,
+}) async {
+  for (var i = 0; i < 2; i++) {
+    await operation();
+  }
+
+  final durations = <int>[];
+  for (var i = 0; i < samples; i++) {
+    final stopwatch = Stopwatch()..start();
+    await operation();
+    stopwatch.stop();
+    durations.add(stopwatch.elapsedMicroseconds);
+  }
+  durations.sort();
+  return durations[durations.length ~/ 2] / 1000;
+}
+
+bool _bytesEqual(Uint8List a, Uint8List b) {
+  if (a.length != b.length) {
+    return false;
+  }
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/example/webcrypto_demo_flutter_app/README.md
+++ b/example/webcrypto_demo_flutter_app/README.md
@@ -26,6 +26,13 @@ flutter test integration_test/jni_hkdf_test.dart \
   -d emulator-name
 ```
 
+To run the Android JNI/JCA PBKDF2 smoke test:
+
+```sh
+flutter test integration_test/jni_pbkdf2_test.dart \
+  -d emulator-name
+```
+
 To run the Android JNI/JCA AES-GCM smoke test:
 
 ```sh

--- a/example/webcrypto_demo_flutter_app/README.md
+++ b/example/webcrypto_demo_flutter_app/README.md
@@ -33,6 +33,13 @@ flutter test integration_test/jni_pbkdf2_test.dart \
   -d emulator-name
 ```
 
+To benchmark PBKDF2 at realistic iteration counts on Android:
+
+```sh
+flutter test integration_test/jni_pbkdf2_benchmark.dart \
+  -d emulator-name
+```
+
 To run the Android JNI/JCA AES-GCM smoke test:
 
 ```sh

--- a/example/webcrypto_demo_flutter_app/integration_test/jni_pbkdf2_benchmark.dart
+++ b/example/webcrypto_demo_flutter_app/integration_test/jni_pbkdf2_benchmark.dart
@@ -1,0 +1,68 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webcrypto/webcrypto.dart';
+
+const _configurations = [
+  (iterations: 1000, samples: 5),
+  (iterations: 10000, samples: 5),
+  (iterations: 100000, samples: 5),
+];
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('benchmarks realistic PBKDF2 iteration counts', (_) async {
+    final password = Uint8List.fromList([0, 1, 2, 0x80, 0xff]);
+    final salt = Uint8List.fromList([0xff, 0x80, 2, 1, 0]);
+    final key = await Pbkdf2SecretKey.importRawKey(password);
+
+    debugPrint('backend,iterations,samples,median_ms');
+    for (final configuration in _configurations) {
+      final iterations = configuration.iterations;
+      final derived = await key.deriveBits(256, Hash.sha256, salt, iterations);
+      expect(derived, hasLength(32));
+
+      final median = await _medianMilliseconds(() async {
+        await key.deriveBits(256, Hash.sha256, salt, iterations);
+      }, samples: configuration.samples);
+      debugPrint(
+        'jni,$iterations,${configuration.samples},'
+        '${median.toStringAsFixed(2)}',
+      );
+    }
+  });
+}
+
+Future<double> _medianMilliseconds(
+  Future<void> Function() operation, {
+  required int samples,
+}) async {
+  await operation();
+
+  final durations = <int>[];
+  for (var i = 0; i < samples; i++) {
+    final stopwatch = Stopwatch()..start();
+    await operation();
+    stopwatch.stop();
+    durations.add(stopwatch.elapsedMicroseconds);
+  }
+  durations.sort();
+  return durations[durations.length ~/ 2] / 1000;
+}

--- a/example/webcrypto_demo_flutter_app/integration_test/jni_pbkdf2_test.dart
+++ b/example/webcrypto_demo_flutter_app/integration_test/jni_pbkdf2_test.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webcrypto/webcrypto.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('public API PBKDF2-HMAC-SHA-256 matches known vector', (_) async {
+    final key = await Pbkdf2SecretKey.importRawKey(utf8.encode('password'));
+    final derived = await key.deriveBits(
+      256,
+      Hash.sha256,
+      utf8.encode('salt'),
+      2,
+    );
+
+    expect(
+      base64Encode(derived),
+      'rk0Mla9rRtMtCt/5KPBt0CowP47zwlHf1uLYWpVHTEM=',
+    );
+  });
+}

--- a/lib/src/impl_jni/impl_jni.pbkdf2.dart
+++ b/lib/src/impl_jni/impl_jni.pbkdf2.dart
@@ -18,7 +18,143 @@ final class _StaticPbkdf2SecretKeyImpl implements StaticPbkdf2SecretKeyImpl {
   const _StaticPbkdf2SecretKeyImpl();
 
   @override
-  Future<Pbkdf2SecretKeyImpl> importRawKey(List<int> keyData) {
-    throw UnimplementedError('Not implemented');
+  Future<Pbkdf2SecretKeyImpl> importRawKey(List<int> keyData) async =>
+      _Pbkdf2SecretKeyImpl(Uint8List.fromList(keyData));
+}
+
+final class _Pbkdf2SecretKeyImpl implements Pbkdf2SecretKeyImpl {
+  _Pbkdf2SecretKeyImpl(this._keyData);
+
+  final Uint8List _keyData;
+
+  @override
+  Future<Uint8List> deriveBits(
+    int length,
+    HashImpl hash,
+    List<int> salt,
+    int iterations,
+  ) async {
+    if (length < 0) {
+      throw ArgumentError.value(
+        length,
+        'length',
+        'must be a non-negative integer',
+      );
+    }
+    if (length % 8 != 0) {
+      throw operationError(
+        'The length for PBKDF2 must be a multiple of 8 bits',
+      );
+    }
+    if (iterations <= 0) {
+      throw operationError(
+        'Iterations <= 0 is not allowed for Pbkdf2SecretKey.deriveBits',
+      );
+    }
+
+    final h = _hmacHashFromHash(hash);
+    if (length == 0) {
+      return Uint8List(0);
+    }
+
+    final password = Uint8List.fromList(_keyData);
+    final saltData = Uint8List.fromList(salt);
+    final lengthInBytes = length ~/ 8;
+    return Isolate.run(
+      () => _derivePbkdf2(
+        password,
+        saltData,
+        iterations,
+        lengthInBytes,
+        h._hmacJcaName,
+      ),
+      debugName: 'JCA PBKDF2',
+    );
+  }
+}
+
+Uint8List _derivePbkdf2(
+  Uint8List password,
+  Uint8List salt,
+  int iterations,
+  int lengthInBytes,
+  String hmacAlgorithm,
+) {
+  try {
+    return jni.using((arena) {
+      final algorithm = hmacAlgorithm.toJString()..releasedBy(arena);
+      final mac = Mac.getInstance(algorithm);
+      if (mac == null) {
+        throw AssertionError('JCA Mac($hmacAlgorithm) returned null');
+      }
+      mac.releasedBy(arena);
+
+      // HMAC with an empty key is equivalent to HMAC with one zero byte, but
+      // JCA's SecretKeySpec rejects an empty key.
+      final normalizedPassword = password.isEmpty ? Uint8List(1) : password;
+      final javaPassword = arena.copyToJByteArray(normalizedPassword);
+      final key = SecretKeySpec(javaPassword, algorithm)..releasedBy(arena);
+      mac.init(key);
+
+      final hashLength = mac.macLength;
+      final blockCount = (lengthInBytes + hashLength - 1) ~/ hashLength;
+      if (blockCount > 0xffffffff) {
+        throw operationError(
+          'Length specified for Pbkdf2SecretKey.deriveBits is too long',
+        );
+      }
+
+      final javaSalt = arena.copyToJByteArray(salt);
+      final counter = jni.JByteArray(4)..releasedBy(arena);
+      final counterBytes = Uint8List(4);
+      final u = jni.JByteArray(hashLength)..releasedBy(arena);
+      final uBytes = Uint8List(hashLength);
+      final block = Uint8List(hashLength);
+      final output = Uint8List(lengthInBytes);
+
+      // TODO: Move the PBKDF2 iteration loop behind a JVM-side helper if this
+      // becomes a performance bottleneck. package:jni currently requires one
+      // Java-to-Dart copy per U value so Dart can apply PBKDF2's XOR step.
+      var outputOffset = 0;
+      for (var blockIndex = 1; blockIndex <= blockCount; blockIndex++) {
+        counterBytes[0] = (blockIndex >>> 24) & 0xff;
+        counterBytes[1] = (blockIndex >>> 16) & 0xff;
+        counterBytes[2] = (blockIndex >>> 8) & 0xff;
+        counterBytes[3] = blockIndex & 0xff;
+        counter.setRange(0, 4, counterBytes);
+
+        if (salt.isNotEmpty) {
+          mac.update$1(javaSalt);
+        }
+        mac.update$1(counter);
+        mac.doFinal$1(u, 0);
+        u.copyRangeToDart(block, 0, hashLength);
+
+        for (var iteration = 1; iteration < iterations; iteration++) {
+          mac.update$1(u);
+          mac.doFinal$1(u, 0);
+          u.copyRangeToDart(uBytes, 0, hashLength);
+          for (var i = 0; i < hashLength; i++) {
+            block[i] ^= uBytes[i];
+          }
+        }
+
+        final remaining = lengthInBytes - outputOffset;
+        final blockLength = math.min(hashLength, remaining);
+        output.setRange(outputOffset, outputOffset + blockLength, block);
+        outputOffset += blockLength;
+      }
+      return output;
+    });
+  } on OperationError {
+    rethrow;
+  } on jni.JThrowable catch (e) {
+    late final String message;
+    try {
+      message = e.message;
+    } finally {
+      e.release();
+    }
+    throw operationError('JCA PBKDF2 derivation failed: $message');
   }
 }

--- a/lib/src/impl_jni/impl_jni.pbkdf2.dart
+++ b/lib/src/impl_jni/impl_jni.pbkdf2.dart
@@ -112,9 +112,9 @@ Uint8List _derivePbkdf2(
       final block = Uint8List(hashLength);
       final output = Uint8List(lengthInBytes);
 
-      // TODO: Move the PBKDF2 iteration loop behind a JVM-side helper if this
-      // becomes a performance bottleneck. package:jni currently requires one
-      // Java-to-Dart copy per U value so Dart can apply PBKDF2's XOR step.
+      // TODO: Batch this loop outside Dart after package-level Java helper
+      // packaging is designed. The experimental path currently performs JNI
+      // calls and one Java-to-Dart copy for every U value.
       var outputOffset = 0;
       for (var blockIndex = 1; blockIndex <= blockCount; blockIndex++) {
         counterBytes[0] = (blockIndex >>> 24) & 0xff;

--- a/test/impl_jni_pbkdf2_test.dart
+++ b/test/impl_jni_pbkdf2_test.dart
@@ -1,0 +1,112 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:webcrypto/webcrypto.dart' show OperationError;
+import 'package:webcrypto/src/impl_ffi/impl_ffi.dart' as ffi_impl;
+import 'package:webcrypto/src/impl_jni/impl_jni.dart' as jni_impl;
+
+import 'src/jni_test_setup.dart'
+    if (dart.library.io) 'src/jni_test_setup_io.dart';
+
+void main() {
+  final skipReason = jniHelperSetupSkipReason;
+
+  setUpAll(() {
+    if (skipReason == null) {
+      spawnJniForDesktopTests();
+    }
+  });
+
+  test('JCA PBKDF2-HMAC-SHA-1 matches RFC 6070 vectors', () async {
+    final key = await jni_impl.webCryptImpl.pbkdf2SecretKey.importRawKey(
+      utf8.encode('password'),
+    );
+    final vectors = [
+      (iterations: 1, expected: 'DGDID5YfDnHzqbUkr2ASBi/gN6Y='),
+      (iterations: 2, expected: '6mwBTcctb4zNHtkqzh1B8NjeiVc='),
+      (iterations: 4096, expected: 'SwB5AbdlSJq+rUnZJvch0GWkKcE='),
+    ];
+
+    for (final vector in vectors) {
+      final derived = await key.deriveBits(
+        160,
+        jni_impl.webCryptImpl.sha1,
+        utf8.encode('salt'),
+        vector.iterations,
+      );
+      expect(base64Encode(derived), vector.expected);
+    }
+  }, skip: skipReason);
+
+  test(
+    'JCA PBKDF2 preserves arbitrary password bytes for every hash',
+    () async {
+      final password = Uint8List.fromList([0, 1, 2, 0x80, 0xff]);
+      final salt = Uint8List.fromList([0xff, 0x80, 2, 1, 0]);
+      final jniKey = await jni_impl.webCryptImpl.pbkdf2SecretKey.importRawKey(
+        password,
+      );
+      final ffiKey = await ffi_impl.webCryptImpl.pbkdf2SecretKey.importRawKey(
+        password,
+      );
+      final hashes = [
+        (jni_impl.webCryptImpl.sha1, ffi_impl.webCryptImpl.sha1),
+        (jni_impl.webCryptImpl.sha256, ffi_impl.webCryptImpl.sha256),
+        (jni_impl.webCryptImpl.sha384, ffi_impl.webCryptImpl.sha384),
+        (jni_impl.webCryptImpl.sha512, ffi_impl.webCryptImpl.sha512),
+      ];
+
+      for (final (jniHash, ffiHash) in hashes) {
+        final actual = await jniKey.deriveBits(512, jniHash, salt, 3);
+        final expected = await ffiKey.deriveBits(512, ffiHash, salt, 3);
+        expect(actual, expected);
+      }
+    },
+    skip: skipReason,
+  );
+
+  test('JCA PBKDF2 supports empty password, salt, and output', () async {
+    final jniKey = await jni_impl.webCryptImpl.pbkdf2SecretKey.importRawKey([]);
+    final ffiKey = await ffi_impl.webCryptImpl.pbkdf2SecretKey.importRawKey([]);
+
+    expect(
+      await jniKey.deriveBits(256, jni_impl.webCryptImpl.sha256, const [], 2),
+      await ffiKey.deriveBits(256, ffi_impl.webCryptImpl.sha256, const [], 2),
+    );
+    expect(
+      await jniKey.deriveBits(0, jni_impl.webCryptImpl.sha256, const [], 1),
+      isEmpty,
+    );
+  }, skip: skipReason);
+
+  test('JCA PBKDF2 validates length and iterations', () async {
+    final key = await jni_impl.webCryptImpl.pbkdf2SecretKey.importRawKey([1]);
+
+    await expectLater(
+      key.deriveBits(7, jni_impl.webCryptImpl.sha256, const [], 1),
+      throwsA(isA<OperationError>()),
+    );
+    await expectLater(
+      key.deriveBits(8, jni_impl.webCryptImpl.sha256, const [], 0),
+      throwsA(isA<OperationError>()),
+    );
+  }, skip: skipReason);
+}


### PR DESCRIPTION
## Summary

Adds the JNI/JCA PBKDF2 implementation on top of the Android JCA backend.

This PR implements:

- raw key import with a defensive copy of the password bytes
- RFC 8018 PBKDF2 using JCA `Mac` as the pseudorandom function
- SHA-1, SHA-256, SHA-384, and SHA-512
- arbitrary raw password bytes without `PBEKeySpec` character conversion
- empty password/salt handling and zero-length output
- byte-aligned output-length and positive-iteration validation
- worker-isolate execution so derivation does not block the caller isolate
- focused RFC/FFI interoperability tests and an Android public-API smoke test

Generated JCA bindings are not changed in this PR. The required `Mac` and
`SecretKeySpec` bindings are already present on `android-jca-branch`.

## Experimental performance limitation

The byte-oriented implementation preserves arbitrary raw password bytes, but the RFC 8018 iteration/XOR loop currently runs in Dart. Each iteration invokes JCA through JNI and copies the intermediate `U` value into Dart for XOR. Benchmarks confirm that this boundary cost is significant at realistic iteration counts.

This is accepted for the experimental backend, but batching remains required before it can be considered production-ready. The design is tracked separately because the native-hook package currently has no supported way to distribute a custom Java helper to consumer Android applications.

Reproducible benchmark commands:
```sh
dart run benchmark/impl_jni_pbkdf2_benchmark.dart
cd example/webcrypto_demo_flutter_app
flutter test integration_test/jni_pbkdf2_benchmark.dart -d emulator-name
cd ../..
```

The desktop harness verifies JNI/FFI output equivalence before reporting median times at 1,000, 10,000, and 100,000 iterations. Android results are timing evidence only and contain no performance assertion.

## Testing

Desktop JNI setup, if it has not been run already:
```sh
dart run jni:setup
```

Verified with:
```sh
dart format --output=none --set-exit-if-changed .
dart analyze benchmark/impl_jni_pbkdf2_benchmark.dart \
  lib/src/impl_jni/impl_jni.pbkdf2.dart \
  test/impl_jni_pbkdf2_test.dart
dart test test/impl_jni_pbkdf2_test.dart
dart test test/webcrypto_test.dart -p vm -n PBKDF2
cd example/webcrypto_demo_flutter_app
flutter test integration_test/jni_pbkdf2_test.dart -d emulator-name
cd ../..
git diff --check
```