### PR TITLE
Validate HMAC key generation length before allocation

### DIFF
--- a/lib/src/impl_ffi/impl_ffi.hmac.dart
+++ b/lib/src/impl_ffi/impl_ffi.hmac.dart
@@ -75,7 +75,7 @@ Future<HmacSecretKeyImpl> hmacSecretKey_generateKey(
 }) async {
   final h = _HashImpl.fromHash(hash);
   length ??= ssl.EVP_MD_size(h._md) * 8;
-  final keyData = Uint8List((length / 8).ceil());
+  final keyData = Uint8List((length + 7) ~/ 8);
   fillRandomBytes(keyData);
 
   return _HmacSecretKeyImpl(_asUint8ListZeroedToBitLength(keyData, length), h);

--- a/lib/src/impl_ffi/impl_ffi.hmac.dart
+++ b/lib/src/impl_ffi/impl_ffi.hmac.dart
@@ -75,7 +75,7 @@ Future<HmacSecretKeyImpl> hmacSecretKey_generateKey(
 }) async {
   final h = _HashImpl.fromHash(hash);
   length ??= ssl.EVP_MD_size(h._md) * 8;
-  final keyData = Uint8List((length + 7) ~/ 8);
+  final keyData = Uint8List((length / 8).ceil());
   fillRandomBytes(keyData);
 
   return _HmacSecretKeyImpl(_asUint8ListZeroedToBitLength(keyData, length), h);

--- a/lib/src/webcrypto/webcrypto.hmac.dart
+++ b/lib/src/webcrypto/webcrypto.hmac.dart
@@ -197,6 +197,9 @@ final class HmacSecretKey {
     if (length != null && length <= 0) {
       throw ArgumentError.value(length, 'length', 'must be positive');
     }
+    if (length != null && length > 0xffffffff) {
+      throw ArgumentError.value(length, 'length', 'must be at most 4294967295');
+    }
 
     final impl = await webCryptImpl.hmacSecretKey.generateKey(
       hash._impl,

--- a/lib/src/webcrypto/webcrypto.hmac.dart
+++ b/lib/src/webcrypto/webcrypto.hmac.dart
@@ -198,7 +198,7 @@ final class HmacSecretKey {
       throw ArgumentError.value(length, 'length', 'must be positive');
     }
     if (length != null && length > 0xffffffff) {
-      throw ArgumentError.value(length, 'length', 'must be at most 4294967295');
+      throw ArgumentError.value(length, 'length', 'too large');
     }
 
     final impl = await webCryptImpl.hmacSecretKey.generateKey(

--- a/test/hmac_generate_key_length_test.dart
+++ b/test/hmac_generate_key_length_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:test/test.dart';
+import 'package:webcrypto/webcrypto.dart';
+
+void main() {
+  for (final length in [0x100000000, 9007199254740992]) {
+    test(
+      'rejects out-of-range HMAC key length $length before allocation',
+      () async {
+        await expectLater(
+          HmacSecretKey.generateKey(Hash.sha256, length: length),
+          throwsA(
+            isA<ArgumentError>().having(
+              (error) => error.invalidValue,
+              'invalidValue',
+              length,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- reject explicit HMAC key lengths outside the WebIDL `unsigned long` range before backend dispatch
- calculate the native key byte length using integer ceiling division
- add regression coverage for the first out-of-range value and a very large value

## Motivation

`HmacSecretKey.generateKey` previously validated only zero and negative lengths. On the native backend, an arbitrarily large positive value reached `Uint8List` allocation, potentially causing an out-of-memory failure instead of a deterministic argument error.

Validating the upper bound in the shared API keeps backend behavior consistent with the `[EnforceRange] unsigned long` type used by Web Crypto.

## Testing

- `dart analyze`
- `dart test -p vm`
- `dart test -p chrome -c dart2js`
- focused regression test with Chrome/dart2wasm

Fixes #358
