### PR TITLE
feat(impl_jni): add JCA ECDH implementation

### DIFF
--- a/example/webcrypto_demo_flutter_app/README.md
+++ b/example/webcrypto_demo_flutter_app/README.md
@@ -67,3 +67,10 @@ To run the Android JNI/JCA ECDSA smoke test:
 flutter test integration_test/jni_ecdsa_test.dart \
   -d emulator-name
 ```
+
+To run the Android JNI/JCA ECDH smoke test:
+
+```sh
+flutter test integration_test/jni_ecdh_test.dart \
+  -d emulator-name
+```

--- a/example/webcrypto_demo_flutter_app/integration_test/jni_ecdh_test.dart
+++ b/example/webcrypto_demo_flutter_app/integration_test/jni_ecdh_test.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:webcrypto/webcrypto.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('public API ECDH supports every named curve', (_) async {
+    for (final testCase in <({EllipticCurve curve, int maxLength})>[
+      (curve: EllipticCurve.p256, maxLength: 256),
+      (curve: EllipticCurve.p384, maxLength: 384),
+      (curve: EllipticCurve.p521, maxLength: 528),
+    ]) {
+      final alice = await EcdhPrivateKey.generateKey(testCase.curve);
+      final bob = await EcdhPrivateKey.generateKey(testCase.curve);
+      final privateKey = await EcdhPrivateKey.importPkcs8Key(
+        await alice.privateKey.exportPkcs8Key(),
+        testCase.curve,
+      );
+      final publicKey = await EcdhPublicKey.importRawKey(
+        await bob.publicKey.exportRawKey(),
+        testCase.curve,
+      );
+
+      final derived = await privateKey.deriveBits(
+        testCase.maxLength,
+        publicKey,
+      );
+      final reciprocal = await bob.privateKey.deriveBits(
+        testCase.maxLength,
+        alice.publicKey,
+      );
+      expect(derived, hasLength(testCase.maxLength ~/ 8));
+      expect(derived, reciprocal);
+
+      final partialLength = testCase.maxLength - 1;
+      final partial = await privateKey.deriveBits(partialLength, publicKey);
+      expect(partial, hasLength((partialLength + 7) ~/ 8));
+      expect(partial.last & 1, 0);
+    }
+  });
+
+  testWidgets('public API ECDH JWK metadata is interoperable', (_) async {
+    final keyPair = await EcdhPrivateKey.generateKey(EllipticCurve.p521);
+    final privateJwk = await keyPair.privateKey.exportJsonWebKey();
+    final publicJwk = await keyPair.publicKey.exportJsonWebKey();
+
+    expect(privateJwk, isNot(contains('use')));
+    expect(publicJwk, isNot(contains('use')));
+    expect(
+      base64Url.decode(base64Url.normalize(privateJwk['x'] as String)),
+      hasLength(66),
+    );
+    expect(
+      base64Url.decode(base64Url.normalize(privateJwk['y'] as String)),
+      hasLength(66),
+    );
+
+    final importedPrivateKey = await EcdhPrivateKey.importJsonWebKey(
+      Map<String, dynamic>.of(privateJwk)
+        ..['use'] = 'enc'
+        ..['alg'] = 'custom-ecdh-algorithm',
+      EllipticCurve.p521,
+    );
+    final importedPublicKey = await EcdhPublicKey.importJsonWebKey(
+      Map<String, dynamic>.of(publicJwk)..['use'] = 'enc',
+      EllipticCurve.p521,
+    );
+    expect(
+      await importedPrivateKey.deriveBits(528, importedPublicKey),
+      await keyPair.privateKey.deriveBits(528, keyPair.publicKey),
+    );
+  });
+}

--- a/lib/src/impl_jni/impl_jni.ec_common.dart
+++ b/lib/src/impl_jni/impl_jni.ec_common.dart
@@ -223,7 +223,7 @@ _EcPublicKeyMaterial _importRawEcPublicKey(
 _EcPrivateKeyMaterial _importJwkEcPrivateKey(
   Map<String, dynamic> jwkData,
   EllipticCurve curve, {
-  required String expectedAlg,
+  required String? expectedAlg,
   required String expectedUse,
 }) {
   final jwk = JsonWebKey.fromJson(jwkData);
@@ -262,7 +262,7 @@ _EcPrivateKeyMaterial _importJwkEcPrivateKey(
 _EcPublicKeyMaterial _importJwkEcPublicKey(
   Map<String, dynamic> jwkData,
   EllipticCurve curve, {
-  required String expectedAlg,
+  required String? expectedAlg,
   required String expectedUse,
 }) {
   final jwk = JsonWebKey.fromJson(jwkData);
@@ -331,7 +331,7 @@ Uint8List _exportRawEcPublicKey(_EcPublicKeyMaterial material) {
 
 Map<String, dynamic> _exportJwkEcPrivateKey(
   _EcPrivateKeyMaterial material, {
-  required String jwkUse,
+  required String? jwkUse,
 }) {
   try {
     return jni.using((arena) {
@@ -366,7 +366,7 @@ Map<String, dynamic> _exportJwkEcPrivateKey(
 
 Map<String, dynamic> _exportJwkEcPublicKey(
   _EcPublicKeyMaterial material, {
-  required String jwkUse,
+  required String? jwkUse,
 }) {
   return JsonWebKey(
     kty: 'EC',
@@ -722,7 +722,7 @@ void _validateEcJwk(
   JsonWebKey jwk,
   EllipticCurve curve, {
   required bool isPrivateKey,
-  required String expectedAlg,
+  required String? expectedAlg,
   required String expectedUse,
 }) {
   void check(bool condition, String prop, String message) {
@@ -740,11 +740,13 @@ void _validateEcJwk(
         ? 'must be present for a private key'
         : 'must not be present for a public key',
   );
-  check(
-    jwk.alg == null || jwk.alg == expectedAlg,
-    'alg',
-    'must be "$expectedAlg", if present',
-  );
+  if (expectedAlg != null) {
+    check(
+      jwk.alg == null || jwk.alg == expectedAlg,
+      'alg',
+      'must be "$expectedAlg", if present',
+    );
+  }
   check(
     jwk.use == null || jwk.use == expectedUse,
     'use',

--- a/lib/src/impl_jni/impl_jni.ecdh.dart
+++ b/lib/src/impl_jni/impl_jni.ecdh.dart
@@ -21,18 +21,129 @@ final class _StaticEcdhPrivateKeyImpl implements StaticEcdhPrivateKeyImpl {
   Future<EcdhPrivateKeyImpl> importPkcs8Key(
     List<int> keyData,
     EllipticCurve curve,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    return _EcdhPrivateKeyImpl(
+      _importPkcs8EcPrivateKey(_asUint8List(keyData), curve),
+    );
+  }
 
   @override
   Future<EcdhPrivateKeyImpl> importJsonWebKey(
     Map<String, dynamic> jwk,
     EllipticCurve curve,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    return _EcdhPrivateKeyImpl(
+      _importJwkEcPrivateKey(
+        jwk,
+        curve,
+        // ECDH has no algorithm-specific JWK `alg` value to validate.
+        expectedAlg: null,
+        expectedUse: 'enc',
+      ),
+    );
+  }
 
   @override
   Future<(EcdhPrivateKeyImpl, EcdhPublicKeyImpl)> generateKey(
     EllipticCurve curve,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    final keyPair = await _generateEcKeyPair(curve);
+    final publicKey = _importSpkiEcPublicKey(keyPair.publicKeyData, curve);
+    final privateKey = _importPkcs8EcPrivateKey(
+      keyPair.privateKeyData,
+      curve,
+      publicPoint: publicKey.point,
+    );
+    return (_EcdhPrivateKeyImpl(privateKey), _EcdhPublicKeyImpl(publicKey));
+  }
+}
+
+final class _EcdhPrivateKeyImpl implements EcdhPrivateKeyImpl {
+  _EcdhPrivateKeyImpl(this._key);
+
+  final _EcPrivateKeyMaterial _key;
+
+  @override
+  Future<Uint8List> deriveBits(int length, EcdhPublicKeyImpl publicKey) async {
+    if (publicKey is! _EcdhPublicKeyImpl) {
+      throw ArgumentError.value(
+        publicKey,
+        'publicKey',
+        'custom implementations of EcdhPublicKey are not supported',
+      );
+    }
+    if (length < 0) {
+      throw ArgumentError.value(length, 'length', 'must be non-negative');
+    }
+    if (_key.curve != publicKey._key.curve) {
+      throw ArgumentError.value(
+        publicKey,
+        'publicKey',
+        'Public and private key for ECDH key derivation have the same '
+            'elliptic curve',
+      );
+    }
+
+    final maxLength = _key.curve._coordinateLength * 8;
+    if (length > maxLength) {
+      throw operationError(
+        'Length in ECDH key derivation is too large. '
+        'Maximum allowed is $maxLength bits.',
+      );
+    }
+    if (length == 0) {
+      return Uint8List(0);
+    }
+
+    final lengthInBytes = (length + 7) ~/ 8;
+    try {
+      return jni.using((arena) {
+        final algorithm = 'ECDH'.toJString()..releasedBy(arena);
+        final agreement = KeyAgreement.getInstance(algorithm);
+        if (agreement == null) {
+          throw AssertionError('JCA ECDH KeyAgreement returned null');
+        }
+        agreement.releasedBy(arena);
+
+        final privateKey = _key.owner.key.as(Key.type)..releasedBy(arena);
+        final peerPublicKey = publicKey._key.owner.key.as(Key.type)
+          ..releasedBy(arena);
+        agreement.init(privateKey);
+        agreement.doPhase(peerPublicKey, true)?.releasedBy(arena);
+
+        final secret = agreement.generateSecret();
+        if (secret == null) {
+          throw AssertionError('JCA ECDH KeyAgreement returned no secret');
+        }
+        secret.releasedBy(arena);
+
+        final fullSecret = _normalizeEcCoordinate(
+          secret.copyToDartBytes(),
+          _key.curve,
+        );
+        final result = Uint8List.fromList(
+          Uint8List.sublistView(fullSecret, 0, lengthInBytes),
+        );
+
+        // WebCrypto returns the leftmost requested bits. Keep the final byte
+        // deterministic when the requested length is not byte-aligned.
+        final zeroBits = lengthInBytes * 8 - length;
+        if (zeroBits > 0) {
+          result.last &= (0xff << zeroBits) & 0xff;
+        }
+        return result;
+      });
+    } on jni.JThrowable catch (e) {
+      throw _ecOperationError(e, 'JCA ECDH key derivation failed');
+    }
+  }
+
+  @override
+  Future<Uint8List> exportPkcs8Key() async => _exportPkcs8EcPrivateKey(_key);
+
+  @override
+  Future<Map<String, dynamic>> exportJsonWebKey() async =>
+      _exportJwkEcPrivateKey(_key, jwkUse: null);
 }
 
 final class _StaticEcdhPublicKeyImpl implements StaticEcdhPublicKeyImpl {
@@ -42,17 +153,51 @@ final class _StaticEcdhPublicKeyImpl implements StaticEcdhPublicKeyImpl {
   Future<EcdhPublicKeyImpl> importRawKey(
     List<int> keyData,
     EllipticCurve curve,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    return _EcdhPublicKeyImpl(
+      _importRawEcPublicKey(_asUint8List(keyData), curve),
+    );
+  }
 
   @override
   Future<EcdhPublicKeyImpl> importSpkiKey(
     List<int> keyData,
     EllipticCurve curve,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    return _EcdhPublicKeyImpl(
+      _importSpkiEcPublicKey(_asUint8List(keyData), curve),
+    );
+  }
 
   @override
   Future<EcdhPublicKeyImpl> importJsonWebKey(
     Map<String, dynamic> jwk,
     EllipticCurve curve,
-  ) => throw UnimplementedError('Not implemented');
+  ) async {
+    return _EcdhPublicKeyImpl(
+      _importJwkEcPublicKey(
+        jwk,
+        curve,
+        // ECDH has no algorithm-specific JWK `alg` value to validate.
+        expectedAlg: null,
+        expectedUse: 'enc',
+      ),
+    );
+  }
+}
+
+final class _EcdhPublicKeyImpl implements EcdhPublicKeyImpl {
+  _EcdhPublicKeyImpl(this._key);
+
+  final _EcPublicKeyMaterial _key;
+
+  @override
+  Future<Uint8List> exportRawKey() async => _exportRawEcPublicKey(_key);
+
+  @override
+  Future<Uint8List> exportSpkiKey() async => _exportSpkiEcPublicKey(_key);
+
+  @override
+  Future<Map<String, dynamic>> exportJsonWebKey() async =>
+      _exportJwkEcPublicKey(_key, jwkUse: null);
 }

--- a/test/impl_jni_ecdh_test.dart
+++ b/test/impl_jni_ecdh_test.dart
@@ -1,0 +1,149 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:webcrypto/src/impl_ffi/impl_ffi.dart' as ffi_impl;
+import 'package:webcrypto/src/impl_interface/impl_interface.dart';
+import 'package:webcrypto/src/impl_jni/impl_jni.dart' as jni_impl;
+
+import 'src/jni_test_setup.dart'
+    if (dart.library.io) 'src/jni_test_setup_io.dart';
+
+void main() {
+  final skipReason = jniHelperSetupSkipReason;
+
+  setUpAll(() {
+    if (skipReason == null) {
+      spawnJniForDesktopTests();
+    }
+  });
+
+  for (final testCase in <({EllipticCurve curve, int maxLength})>[
+    (curve: EllipticCurve.p256, maxLength: 256),
+    (curve: EllipticCurve.p384, maxLength: 384),
+    (curve: EllipticCurve.p521, maxLength: 528),
+  ]) {
+    test('JCA ECDH ${testCase.curve.name} interoperates with FFI', () async {
+      final alice = await jni_impl.webCryptImpl.ecdhPrivateKey.generateKey(
+        testCase.curve,
+      );
+      final bob = await jni_impl.webCryptImpl.ecdhPrivateKey.generateKey(
+        testCase.curve,
+      );
+
+      final ffiAlice = await ffi_impl.webCryptImpl.ecdhPrivateKey
+          .importPkcs8Key(await alice.$1.exportPkcs8Key(), testCase.curve);
+      final ffiBob = await ffi_impl.webCryptImpl.ecdhPublicKey.importSpkiKey(
+        await bob.$2.exportSpkiKey(),
+        testCase.curve,
+      );
+
+      for (final length in <int>[testCase.maxLength, testCase.maxLength - 1]) {
+        final jcaDerived = await alice.$1.deriveBits(length, bob.$2);
+        final reciprocal = await bob.$1.deriveBits(length, alice.$2);
+        final ffiDerived = await ffiAlice.deriveBits(length, ffiBob);
+
+        expect(jcaDerived, hasLength((length + 7) ~/ 8));
+        expect(jcaDerived, reciprocal);
+        expect(jcaDerived, ffiDerived);
+        if (length % 8 != 0) {
+          expect(jcaDerived.last & ((1 << (8 - (length % 8))) - 1), 0);
+        }
+      }
+
+      final rawPublicKey = await bob.$2.exportRawKey();
+      final importedPublicKey = await jni_impl.webCryptImpl.ecdhPublicKey
+          .importRawKey(rawPublicKey, testCase.curve);
+      expect(
+        await alice.$1.deriveBits(testCase.maxLength, importedPublicKey),
+        await alice.$1.deriveBits(testCase.maxLength, bob.$2),
+      );
+    }, skip: skipReason);
+  }
+
+  test('JCA ECDH validates JWK metadata and derives bounds', () async {
+    final alice = await jni_impl.webCryptImpl.ecdhPrivateKey.generateKey(
+      EllipticCurve.p256,
+    );
+    final bob = await jni_impl.webCryptImpl.ecdhPrivateKey.generateKey(
+      EllipticCurve.p256,
+    );
+    final privateJwk = await alice.$1.exportJsonWebKey();
+    final publicJwk = await bob.$2.exportJsonWebKey();
+
+    expect(privateJwk['kty'], 'EC');
+    expect(privateJwk['crv'], 'P-256');
+    expect(privateJwk, isNot(contains('use')));
+    expect(publicJwk, isNot(contains('d')));
+    expect(publicJwk, isNot(contains('use')));
+
+    final withUse = Map<String, dynamic>.of(publicJwk)..['use'] = 'enc';
+    final withArbitraryAlg = Map<String, dynamic>.of(withUse)
+      ..['alg'] = 'custom-ecdh-algorithm';
+    final importedPublicKey = await jni_impl.webCryptImpl.ecdhPublicKey
+        .importJsonWebKey(withArbitraryAlg, EllipticCurve.p256);
+    expect(
+      await alice.$1.deriveBits(256, importedPublicKey),
+      await alice.$1.deriveBits(256, bob.$2),
+    );
+
+    final wrongUse = Map<String, dynamic>.of(publicJwk)..['use'] = 'sig';
+    await expectLater(
+      jni_impl.webCryptImpl.ecdhPublicKey.importJsonWebKey(
+        wrongUse,
+        EllipticCurve.p256,
+      ),
+      throwsA(isA<FormatException>()),
+    );
+    await expectLater(
+      alice.$1.deriveBits(257, bob.$2),
+      throwsA(isA<OperationError>()),
+    );
+    await expectLater(alice.$1.deriveBits(-1, bob.$2), throwsArgumentError);
+    expect(await alice.$1.deriveBits(0, bob.$2), isEmpty);
+
+    final p384 = await jni_impl.webCryptImpl.ecdhPrivateKey.generateKey(
+      EllipticCurve.p384,
+    );
+    await expectLater(alice.$1.deriveBits(256, p384.$2), throwsArgumentError);
+  }, skip: skipReason);
+
+  test('JCA ECDH key wrappers cannot cross isolate boundaries', () async {
+    final keyPair = await jni_impl.webCryptImpl.ecdhPrivateKey.generateKey(
+      EllipticCurve.p256,
+    );
+    for (final key in <Object>[keyPair.$1, keyPair.$2]) {
+      final ready = ReceivePort();
+      final isolate = await Isolate.spawn(_waitForMessage, ready.sendPort);
+      try {
+        final destination = await ready.first as SendPort;
+        expect(() => destination.send(key), throwsArgumentError);
+      } finally {
+        isolate.kill(priority: Isolate.immediate);
+        ready.close();
+      }
+    }
+  }, skip: skipReason);
+}
+
+void _waitForMessage(SendPort ready) {
+  final messages = ReceivePort();
+  ready.send(messages.sendPort);
+}


### PR DESCRIPTION
## Summary

Adds the JNI/JCA ECDH implementation on top of the Android JCA backend.

This PR implements:
- P-256, P-384, and P-521 key generation and ECDH derivation through JCA `KeyAgreement`
- PKCS#8 private-key and SPKI/raw public-key import/export
- ECDH JWK import/export with curve and `use: "enc"` validation when present
- WebCrypto `deriveBits` length validation, byte normalization, and masking for non-byte-aligned results
- persistent isolate-unsendable JCA key ownership
- focused desktop JNI/FFI interoperability tests and Android integration tests

ECDH has no algorithm-specific JWK `alg` value, so the JNI backend deliberately matches FFI by accepting that optional field. JWK export omits `use`, matching browser and FFI behavior; imports accept `use: "enc"` when supplied.

## Testing

Desktop JNI setup, if it has not been run already:
```sh
dart run jni:setup
```

Verified with:
```sh
dart analyze
dart format --output=none --set-exit-if-changed .
dart test test/impl_jni_ecdh_test.dart
dart test test/webcrypto_test.dart -p vm -n ECDH
cd example/webcrypto_demo_flutter_app
flutter test integration_test/jni_ecdh_test.dart -d emulator-name
cd ../..
git diff --check
```