### PR TITLE
fix(hmac): reject empty imported keys

### DIFF
--- a/lib/src/impl_ffi/impl_ffi.hmac.dart
+++ b/lib/src/impl_ffi/impl_ffi.hmac.dart
@@ -37,6 +37,7 @@ Future<HmacSecretKeyImpl> hmacSecretKey_importRawKey(
   HashImpl hash, {
   int? length,
 }) async {
+  _checkData(keyData.isNotEmpty, message: 'HMAC key data must not be empty');
   return _HmacSecretKeyImpl(
     _asUint8ListZeroedToBitLength(keyData, length),
     _HashImpl.fromHash(hash),

--- a/lib/src/testing/regression/hmac_empty_key.dart
+++ b/lib/src/testing/regression/hmac_empty_key.dart
@@ -12,36 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@TestOn('vm')
-library;
-
-import 'package:test/test.dart';
 import 'package:webcrypto/webcrypto.dart';
 
-final _throwsEmptyKey = throwsA(
-  isA<FormatException>().having(
-    (error) => error.message,
-    'message',
-    'HMAC key data must not be empty',
-  ),
-);
+import '../utils/utils.dart';
 
-void main() {
-  test('rejects an empty raw key', () async {
-    await expectLater(
+List<({String name, Future<void> Function() test})> tests() => [
+  (
+    name: 'HMAC rejects empty raw keys',
+    test: () => _expectEmptyKeyRejected(
       HmacSecretKey.importRawKey(const [], Hash.sha256),
-      _throwsEmptyKey,
-    );
-  });
-
-  test('rejects an empty JWK key', () async {
-    await expectLater(
+    ),
+  ),
+  (
+    name: 'HMAC rejects empty JWK keys',
+    test: () => _expectEmptyKeyRejected(
       HmacSecretKey.importJsonWebKey(const {
         'kty': 'oct',
         'alg': 'HS256',
         'k': '',
       }, Hash.sha256),
-      _throwsEmptyKey,
+    ),
+  ),
+];
+
+Future<void> _expectEmptyKeyRejected(Future<HmacSecretKey> import) async {
+  try {
+    await import;
+  } on FormatException catch (error) {
+    check(
+      error.message == 'HMAC key data must not be empty',
+      'Expected an empty HMAC key error',
     );
-  });
+    return;
+  }
+  check(false, 'Expected an empty HMAC key to be rejected');
 }

--- a/lib/src/testing/testing.dart
+++ b/lib/src/testing/testing.dart
@@ -31,6 +31,7 @@ import 'webcrypto/rsassapkcs1v15.dart' as rsassapkcs1v15;
 import 'webcrypto/random.dart' as random;
 import 'webcrypto/digest.dart' as digest;
 import 'regression/derive_bits_zero_length.dart' as derive_bits_zero_length;
+import 'regression/hmac_empty_key.dart' as hmac_empty_key;
 import 'regression/issue_60_trailing_bytes.dart' as issue_60_trailing_bytes;
 import 'regression/rsa_oaep_sha1_jwk_alg.dart' as rsa_oaep_sha1_jwk_alg;
 
@@ -63,6 +64,7 @@ void runAllTests(
     ...digest.tests(),
     ...issue_60_trailing_bytes.tests(),
     ...derive_bits_zero_length.tests(),
+    ...hmac_empty_key.tests(),
     ...rsa_oaep_sha1_jwk_alg.tests(),
   ];
 

--- a/test/hmac_empty_key_test.dart
+++ b/test/hmac_empty_key_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+library;
+
+import 'package:test/test.dart';
+import 'package:webcrypto/webcrypto.dart';
+
+final _throwsEmptyKey = throwsA(
+  isA<FormatException>().having(
+    (error) => error.message,
+    'message',
+    'HMAC key data must not be empty',
+  ),
+);
+
+void main() {
+  test('rejects an empty raw key', () async {
+    await expectLater(
+      HmacSecretKey.importRawKey(const [], Hash.sha256),
+      _throwsEmptyKey,
+    );
+  });
+
+  test('rejects an empty JWK key', () async {
+    await expectLater(
+      HmacSecretKey.importJsonWebKey(const {
+        'kty': 'oct',
+        'alg': 'HS256',
+        'k': '',
+      }, Hash.sha256),
+      _throwsEmptyKey,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Native HMAC imports currently accept empty key material, while browser implementations reject the same input. This creates inconsistent behavior depending on which backend an application uses.

This change validates the key data in the shared native HMAC import path and rejects empty keys before constructing the native key object. Because raw and JWK imports use the same path, the fix covers both formats without duplicating validation logic.

## What changed

- Reject empty native HMAC key material with a `FormatException`.
- Add regression coverage for:
  - empty raw HMAC keys
  - JWK HMAC keys with an empty `k` value

## Why this matters

An HMAC key must contain key material. Accepting an empty key can hide invalid input and cause code to behave differently between native and browser environments. Rejecting it during import makes the behavior predictable and fails early with a clear error.

## Validation

- `dart format --output none --set-exit-if-changed .`
- `dart analyze --fatal-warnings .`
- Full VM test suite
- Full Chrome test suite using Dart2JS
- Full Chrome test suite using Dart2Wasm

Fixes #363