### PR TITLE
docs: move Hash.digestBytes example to a separate file

### DIFF
--- a/example/webcrypto/hash/digest_bytes.dart
+++ b/example/webcrypto/hash/digest_bytes.dart
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ignore_for_file: avoid_print
+
+// #region example
+import 'dart:convert' show base64, utf8;
+
+import 'package:webcrypto/webcrypto.dart';
+
+Future<void> main() async {
+  // Convert 'hello world' to a byte array
+  final bytesToHash = utf8.encode('hello world');
+
+  // Compute hash of bytesToHash with sha-256
+  List<int> hash = await Hash.sha256.digestBytes(bytesToHash);
+
+  // Print the base64 encoded hash
+  print(base64.encode(hash));
+}
+
+// #endregion

--- a/lib/src/webcrypto/webcrypto.digest.dart
+++ b/lib/src/webcrypto/webcrypto.digest.dart
@@ -38,21 +38,7 @@ abstract final class Hash {
   /// Compute a cryptographic hash-sum of [data] using this [Hash].
   ///
   /// **Example**
-  /// ```dart
-  /// import 'dart:convert' show base64, utf8;
-  /// import 'package:webcrypto/webcrypto.dart';
-  ///
-  /// Future<void> main() async {
-  ///   // Convert 'hello world' to a byte array
-  ///   final bytesToHash = utf8.encode('hello world');
-  ///
-  ///   // Compute hash of bytesToHash with sha-256
-  ///   List<int> hash = await Hash.sha256.digestBytes(bytesToHash);
-  ///
-  ///   // Print the base64 encoded hash
-  ///   print(base64.encode(hash));
-  /// }
-  /// ```
+  /// {@example /example/webcrypto/hash/digest_bytes.dart#example}
   Future<Uint8List> digestBytes(List<int> data) => _impl.digestBytes(data);
 
   /// Compute a cryptographic hash-sum of [data] stream using this [Hash].


### PR DESCRIPTION
## Summary

- move the existing `Hash.digestBytes` example to `example/webcrypto/hash/digest_bytes.dart`
- reference the extracted example from the API documentation with `{@example /example/webcrypto/hash/digest_bytes.dart#example}`
- keep the example behavior unchanged; add only the license header, region markers, and the `avoid_print` suppression required after extraction

This makes the example visible to formatting and analysis tools as requested in #283.

## Validation

- `dart format --output=none --set-exit-if-changed .` — 122 files checked, 0 changed
- `dart analyze` — no issues found
- `dart compile js example/webcrypto/hash/digest_bytes.dart -o /tmp/digest_bytes.js` — succeeded

Native execution was not run because the Dart container does not include CMake, which the package's native build hook requires.

Towards #283.
