### PR TITLE
fix(ecdh): validate browser deriveBits lengths

### DIFF
--- a/lib/src/impl_js/impl_js.ecdh.dart
+++ b/lib/src/impl_js/impl_js.ecdh.dart
@@ -33,6 +33,7 @@ Future<EcdhPrivateKeyImpl> ecdhPrivateKey_importPkcs8Key(
       _usagesDeriveBits,
       'private',
     ),
+    curve,
   );
 }
 
@@ -56,6 +57,7 @@ Future<EcdhPrivateKeyImpl> ecdhPrivateKey_importJsonWebKey(
       _usagesDeriveBits,
       'private',
     ),
+    curve,
   );
 }
 
@@ -66,7 +68,7 @@ ecdhPrivateKey_generateKey(EllipticCurve curve) async {
     _usagesDeriveBits,
   );
   return (
-    privateKey: _EcdhPrivateKeyImpl(pair.privateKey),
+    privateKey: _EcdhPrivateKeyImpl(pair.privateKey, curve),
     publicKey: _EcdhPublicKeyImpl(pair.publicKey),
   );
 }
@@ -158,7 +160,14 @@ final class _StaticEcdhPrivateKeyImpl implements StaticEcdhPrivateKeyImpl {
 
 final class _EcdhPrivateKeyImpl implements EcdhPrivateKeyImpl {
   final subtle.JSCryptoKey _key;
-  _EcdhPrivateKeyImpl(this._key);
+  final int _maxLength;
+
+  _EcdhPrivateKeyImpl(this._key, EllipticCurve curve)
+    : _maxLength = switch (curve) {
+        EllipticCurve.p256 => 256,
+        EllipticCurve.p384 => 384,
+        EllipticCurve.p521 => 528,
+      };
 
   @override
   String toString() {
@@ -172,6 +181,15 @@ final class _EcdhPrivateKeyImpl implements EcdhPrivateKeyImpl {
         publicKey,
         'publicKey',
         'custom implementations of EcdhPublicKeyImpl is not supported',
+      );
+    }
+    if (length < 0) {
+      throw ArgumentError.value(length, 'length', 'must be non-negative');
+    }
+    if (length > _maxLength) {
+      throw operationError(
+        'Length in ECDH key derivation is too large. '
+        'Maximum allowed is $_maxLength bits.',
       );
     }
     final lengthInBytes = (length / 8).ceil();

--- a/lib/src/testing/regression/ecdh_invalid_length.dart
+++ b/lib/src/testing/regression/ecdh_invalid_length.dart
@@ -1,0 +1,74 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:webcrypto/webcrypto.dart';
+
+import '../utils/utils.dart';
+
+final _cases = [
+  (curve: EllipticCurve.p256, maxLength: 256),
+  (curve: EllipticCurve.p384, maxLength: 384),
+  (curve: EllipticCurve.p521, maxLength: 528),
+];
+
+List<({String name, Future<void> Function() test})> tests() => [
+  for (final (:curve, :maxLength) in _cases)
+    (
+      name: 'ECDH rejects invalid lengths for $curve',
+      test: () async {
+        final alice = await EcdhPrivateKey.generateKey(curve);
+        final bob = await EcdhPrivateKey.generateKey(curve);
+
+        await _expectOperationError(
+          alice.privateKey.deriveBits(maxLength + 1, bob.publicKey),
+        );
+
+        if (curve == EllipticCurve.p256) {
+          await _expectArgumentError(
+            alice.privateKey.deriveBits(-1, bob.publicKey),
+          );
+          for (final length in [
+            0xfffffff9,
+            0xffffffff,
+            0x100000000,
+            0x100000001,
+          ]) {
+            await _expectOperationError(
+              alice.privateKey.deriveBits(length, bob.publicKey),
+            );
+          }
+        }
+      },
+    ),
+];
+
+Future<void> _expectArgumentError(Future<List<int>> operation) async {
+  var threw = false;
+  try {
+    await operation;
+  } on ArgumentError {
+    threw = true;
+  }
+  check(threw, 'Expected ArgumentError for invalid ECDH length');
+}
+
+Future<void> _expectOperationError(Future<List<int>> operation) async {
+  var threw = false;
+  try {
+    await operation;
+  } on OperationError {
+    threw = true;
+  }
+  check(threw, 'Expected OperationError for invalid ECDH length');
+}

--- a/lib/src/testing/testing.dart
+++ b/lib/src/testing/testing.dart
@@ -31,6 +31,7 @@ import 'webcrypto/rsassapkcs1v15.dart' as rsassapkcs1v15;
 import 'webcrypto/random.dart' as random;
 import 'webcrypto/digest.dart' as digest;
 import 'regression/derive_bits_zero_length.dart' as derive_bits_zero_length;
+import 'regression/ecdh_invalid_length.dart' as ecdh_invalid_length;
 import 'regression/issue_60_trailing_bytes.dart' as issue_60_trailing_bytes;
 import 'regression/jwk_base64url.dart' as jwk_base64url;
 import 'regression/rsa_oaep_sha1_jwk_alg.dart' as rsa_oaep_sha1_jwk_alg;
@@ -65,6 +66,7 @@ void runAllTests(
     ...issue_60_trailing_bytes.tests(),
     ...jwk_base64url.tests(),
     ...derive_bits_zero_length.tests(),
+    ...ecdh_invalid_length.tests(),
     ...rsa_oaep_sha1_jwk_alg.tests(),
   ];
 


### PR DESCRIPTION
## Summary

- retain the selected ECDH curve limit in the browser private-key wrapper
- reject negative and curve-oversized lengths before byte rounding and Web IDL conversion
- add shared regression coverage for every supported curve and 32-bit wrap boundaries

## Relationship to #249

PR #249 adds coverage for the documented maximum length and the first invalid bit length on each supported curve. This PR is a follow-up that addresses a separate browser implementation bug: negative and large Dart integers can be rounded and then wrapped during Web IDL conversion before the browser validates them.

The `maximum + 1` cases overlap with #249's boundary coverage. The new regression cases exercise negative input and values around the 32-bit Web IDL boundary (`0xfffffff9`, `0xffffffff`, `0x100000000`, and `0x100000001`), which #249 does not cover and which require the implementation change in this PR.

## Rationale

The browser implementation rounded `length` to bytes before calling `SubtleCrypto.deriveBits`. Invalid Dart integers could therefore wrap during Web IDL conversion and produce an empty or incorrectly sized secret, or surface an unrelated `StateError`, instead of matching the native implementation's validation.

The checks are performed before conversion and preserve existing behavior for zero and valid non-byte-aligned lengths.

Fixes #366.

## Validation

- `dart format --output none --set-exit-if-changed .`
- `dart analyze --fatal-warnings .`
- `dart test test/webcrypto_test.dart -p vm` (1,447 tests)
- `dart test test/webcrypto_test.dart -p chrome -c dart2js` (1,443 tests)
- `dart test test/webcrypto_test.dart -p chrome -c dart2wasm` (1,443 tests)
