### PR TITLE
fix(random): validate supported typed data inputs

### DIFF
--- a/lib/src/testing/webcrypto/random.dart
+++ b/lib/src/testing/webcrypto/random.dart
@@ -74,6 +74,22 @@ List<({String name, Future<void> Function() test})> tests() {
     isNotAllZero(data);
   });
 
+  test('fillRandomBytes: unsupported TypedData types', () async {
+    for (final data in <TypedData>[
+      Float32List(32),
+      Float64List(32),
+      ByteData(32),
+    ]) {
+      ArgumentError? error;
+      try {
+        fillRandomBytes(data);
+      } on ArgumentError catch (e) {
+        error = e;
+      }
+      check(error?.name == 'destination', 'Should reject ${data.runtimeType}');
+    }
+  });
+
   test('fillRandomBytes: Maximum buffer', () async {
     final data = Uint8List(64 * 1024);
     isAllZero(data);

--- a/lib/src/webcrypto/webcrypto.random.dart
+++ b/lib/src/webcrypto/webcrypto.random.dart
@@ -41,6 +41,19 @@ void fillRandomBytes(
   // Note: Uint8List and friends all implement TypedData, but dartdoc has a bug
   //       where it's not reporting this.
 ) {
+  if (destination is! Uint8List &&
+      destination is! Uint16List &&
+      destination is! Uint32List &&
+      destination is! Int8List &&
+      destination is! Int16List &&
+      destination is! Int32List) {
+    throw ArgumentError.value(
+      destination,
+      'destination',
+      'unsupported TypedData type',
+    );
+  }
+
   // This limitation is given in the Web Cryptography Specification, see:
   // https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues
   if (destination.lengthInBytes > 65536) {


### PR DESCRIPTION
## Summary

- validate `fillRandomBytes` input types at the shared API boundary
- reject unsupported `TypedData` implementations consistently across backends
- add shared regression coverage for `Float32List`, `Float64List`, and `ByteData`

## Testing

- `dart analyze --fatal-warnings .`
- `dart test -p vm test/webcrypto_test.dart`
- `dart test -p chrome -c dart2js,dart2wasm test/webcrypto_test.dart -n 'fillRandomBytes'`

Fixes #370
