### PR TITLE
fix(impl_jni): configure RSA-PSS parameters after initialization

### DIFF
--- a/lib/src/impl_jni/impl_jni.rsapss.dart
+++ b/lib/src/impl_jni/impl_jni.rsapss.dart
@@ -169,8 +169,11 @@ Future<Uint8List> _signRsaPssStream(
 ) async {
   final arena = jni.Arena();
   try {
-    final signature = _createRsaPssSignature(arena, hash, saltLength);
+    final signature = _getRsaPssSignature(arena, hash);
     signature.initSign(key.key);
+    // The tested Android JCA provider resets PSS parameters during
+    // initialization.
+    _configureRsaPssSignature(arena, signature, hash, saltLength);
 
     final buffer = jni.JByteArray(_defaultChunkSize)..releasedBy(arena);
     await for (final chunk in data) {
@@ -199,8 +202,11 @@ Future<bool> _verifyRsaPssStream(
 ) async {
   final arena = jni.Arena();
   try {
-    final verifier = _createRsaPssSignature(arena, hash, saltLength);
+    final verifier = _getRsaPssSignature(arena, hash);
     verifier.initVerify(key.key);
+    // The tested Android JCA provider resets PSS parameters during
+    // initialization.
+    _configureRsaPssSignature(arena, verifier, hash, saltLength);
 
     final buffer = jni.JByteArray(_defaultChunkSize)..releasedBy(arena);
     await for (final chunk in data) {
@@ -223,13 +229,12 @@ Future<bool> _verifyRsaPssStream(
   }
 }
 
-Signature _createRsaPssSignature(
+void _configureRsaPssSignature(
   jni.Arena arena,
+  Signature signature,
   _HashImpl hash,
   int saltLength,
 ) {
-  final signature = _getRsaPssSignature(arena, hash);
-
   final hashName = hash._jcaName.toJString()..releasedBy(arena);
   final mgfName = 'MGF1'.toJString()..releasedBy(arena);
   final mgfParameters = MGF1ParameterSpec(hashName)..releasedBy(arena);
@@ -241,7 +246,6 @@ Signature _createRsaPssSignature(
     1,
   )..releasedBy(arena);
   signature.parameter = parameters;
-  return signature;
 }
 
 // TODO: Decide the RSA-PSS policy for Android API 21-22. Android only


### PR DESCRIPTION
## Summary

- Configure `PSSParameterSpec` after `Signature.initSign` or `Signature.initVerify`.
- Preserve the requested digest, MGF1 digest, salt length, and trailer field.
- Fix verification of externally generated signatures that use non-default salt lengths on the tested Android provider.

## Root Cause

The tested Android JCA provider resets its active RSA-PSS parameters during signature initialization. The previous order configured `PSSParameterSpec` before initialization, so the provider replaced the requested values with its defaults.

The backend now obtains and initializes `Signature` before applying the requested parameters. This PR does not change generated bindings or persistent key ownership.

Issue #371 tracks API 24-26 providers that return non-CRT private-key wrappers and block the shared RSA tests before the PSS operation runs.

## Testing

Desktop JNI setup, if needed:

- `dart run jni:setup`

Verified with:

- `dart format --output=none --set-exit-if-changed lib/src/impl_jni/impl_jni.rsapss.dart`
- `git diff --check`
- `dart analyze lib/src/impl_jni/impl_jni.rsapss.dart test/impl_jni_rsapss_test.dart`
- `dart test test/impl_jni_rsapss_test.dart`
- `dart test test/webcrypto_test.dart -p vm -n 'RSA-PSS'`
- `flutter test integration_test/webcrypto_test.dart -d emulator-name --name 'RSA-PSS'` from `example/webcrypto_demo_flutter_app`

The focused desktop suite passes 3 cases, the shared desktop RSA-PSS selection passes 366 cases, and the tested Android API 36 x86_64 provider passes all 366 shared RSA-PSS cases. API 24-26 remain blocked by the separate RSA private-key import issue.

Follow-up to #341.