### PR TITLE
fix(impl_jni): validate JWK base64url and RSA public imports

### DIFF
--- a/lib/src/impl_jni/impl_jni.rsa_common.dart
+++ b/lib/src/impl_jni/impl_jni.rsa_common.dart
@@ -85,7 +85,12 @@ _JcaKeyOwner _importJwkRsaPrivateKey(
   required String expectedUse,
 }) {
   final jwk = JsonWebKey.fromJson(jwkData);
-  _validateRsaJwk(jwk, expectedAlg: expectedAlg, expectedUse: expectedUse);
+  _validateRsaJwk(
+    jwk,
+    isPrivateKey: true,
+    expectedAlg: expectedAlg,
+    expectedUse: expectedUse,
+  );
 
   final n = _readRsaJwkInteger(jwk.n, 'n');
   final e = _readRsaJwkInteger(jwk.e, 'e');
@@ -128,7 +133,12 @@ _JcaKeyOwner _importJwkRsaPublicKey(
   required String expectedUse,
 }) {
   final jwk = JsonWebKey.fromJson(jwkData);
-  _validateRsaJwk(jwk, expectedAlg: expectedAlg, expectedUse: expectedUse);
+  _validateRsaJwk(
+    jwk,
+    isPrivateKey: false,
+    expectedAlg: expectedAlg,
+    expectedUse: expectedUse,
+  );
 
   final n = _readRsaJwkInteger(jwk.n, 'n');
   final e = _readRsaJwkInteger(jwk.e, 'e');
@@ -521,6 +531,7 @@ String _encodeRsaBigInteger(jni.Arena arena, BigInteger? value, String name) {
 
 void _validateRsaJwk(
   JsonWebKey jwk, {
+  required bool isPrivateKey,
   required String expectedAlg,
   required String expectedUse,
 }) {
@@ -538,6 +549,13 @@ void _validateRsaJwk(
     jwk.use == null || jwk.use == expectedUse,
     'use',
     'must be "$expectedUse", if present',
+  );
+  check(
+    isPrivateKey ? jwk.d != null : jwk.d == null,
+    'd',
+    isPrivateKey
+        ? 'must be present for a private key'
+        : 'must not be present for a public key',
   );
 }
 

--- a/lib/src/impl_jni/impl_jni.utils.dart
+++ b/lib/src/impl_jni/impl_jni.utils.dart
@@ -65,7 +65,11 @@ Uint8List _jwkDecodeBase64UrlNoPadding(String unpadded, String prop) {
       unpadded.length + ((4 - (unpadded.length % 4)) % 4),
       '=',
     );
-    return base64Url.decode(padded);
+    final decoded = base64Url.decode(padded);
+    if (_jwkEncodeBase64UrlNoPadding(decoded) != unpadded) {
+      throw const FormatException();
+    }
+    return decoded;
   } on FormatException {
     throw FormatException(
       'JWK property "$prop" is not url-safe base64 without padding',

--- a/test/impl_jni_hmac_test.dart
+++ b/test/impl_jni_hmac_test.dart
@@ -115,6 +115,25 @@ void main() {
     expect(await imported.signBytes(data), await key.signBytes(data));
   }, skip: skipReason);
 
+  test('JCA JWK imports require canonical unpadded base64url', () {
+    for (final keyData in ['AQ==', '+w']) {
+      expect(
+        () => jni_impl.webCryptImpl.hmacSecretKey.importJsonWebKey({
+          'kty': 'oct',
+          'alg': 'HS256',
+          'k': keyData,
+        }, jni_impl.webCryptImpl.sha256),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('is not url-safe base64 without padding'),
+          ),
+        ),
+      );
+    }
+  }, skip: skipReason);
+
   test('JCA HMAC generateKey supports non-byte-aligned key lengths', () async {
     final key = await jni_impl.webCryptImpl.hmacSecretKey.generateKey(
       jni_impl.webCryptImpl.sha512,

--- a/test/impl_jni_rsassapkcs1v15_test.dart
+++ b/test/impl_jni_rsassapkcs1v15_test.dart
@@ -115,6 +115,21 @@ void main() {
 
   test('JCA RSA public imports validate the modulus and exponent', () async {
     final publicJwk = await publicKey.exportJsonWebKey();
+    final privateJwk = await privateKey.exportJsonWebKey();
+
+    await expectLater(
+      jni_impl.webCryptImpl.rsaSsaPkcs1v15PublicKey.importJsonWebKey(
+        privateJwk,
+        jni_impl.webCryptImpl.sha256,
+      ),
+      throwsA(
+        isA<FormatException>().having(
+          (e) => e.message,
+          'message',
+          contains('must not be present for a public key'),
+        ),
+      ),
+    );
 
     final invalidExponent = Map<String, dynamic>.of(publicJwk)..['e'] = 'BA';
     await expectLater(


### PR DESCRIPTION
## Summary

- Require canonical unpadded base64url for each JWK field decoded as bytes by the JNI backend.
- Require `d` during RSA private JWK import.
- Reject `d` during RSA public JWK import.
- Add focused HMAC and RSASSA regression coverage.

## Root Cause

The shared JNI decoder accepted padded values and characters from the standard Base64 alphabet. It now re-encodes the decoded bytes as canonical unpadded base64url and compares that value with the original input. The shared JNI RSA validator also did not distinguish private JWKs from public JWK imports, so public import accepted private material and discarded it.

The base64url decoder is shared by symmetric, RSA, and EC key imports. The RSA validation is shared by RSA-OAEP, RSA-PSS, and RSASSA-PKCS1-v1_5. 

## Testing

Desktop JNI setup, if needed:

- `dart run jni:setup`

Verified on the current branch with:

- `dart format --output=none --set-exit-if-changed lib/src/impl_jni/impl_jni.rsa_common.dart lib/src/impl_jni/impl_jni.utils.dart test/impl_jni_hmac_test.dart test/impl_jni_rsassapkcs1v15_test.dart`
- `git diff --check`
- `dart analyze lib/src/impl_jni/impl_jni.rsa_common.dart lib/src/impl_jni/impl_jni.utils.dart test/impl_jni_hmac_test.dart test/impl_jni_rsassapkcs1v15_test.dart`
- `dart test test/impl_jni_hmac_test.dart`
- `dart test test/impl_jni_rsassapkcs1v15_test.dart`
- `dart test test/webcrypto_test.dart -p vm -n '^JWK:'`
- `flutter test integration_test/webcrypto_test.dart -d emulator-name --name 'JWK:'` from `example/webcrypto_demo_flutter_app`

The HMAC suite passes 5 cases, the RSASSA suite passes 8 cases, and the shared base64url regression from #329 passes 2 cases on desktop JNI and the tested Android 16 x86_64 emulator. The focused RSASSA suite covers the RSA public/private rule from #333 until the separate desktop-JNI bootstrap makes `test/rsa_jwk_validation_test.dart` runnable through JNI.