### PR TITLE
test(jni): initialize desktop JNI in standalone public-API tests

### DIFF
--- a/test/hkdf_output_length_test.dart
+++ b/test/hkdf_output_length_test.dart
@@ -18,13 +18,22 @@ library;
 import 'package:test/test.dart';
 import 'package:webcrypto/webcrypto.dart';
 
+import 'src/jni_test_setup.dart'
+    if (dart.library.io) 'src/jni_test_setup_io.dart';
+
 const _lengthTooLong =
     'Length specified for HkdfSecretKey.deriveBits is too long';
 
 void main() {
+  final skipReason = jniHelperSetupSkipReason;
   late HkdfSecretKey key;
 
   setUpAll(() async {
+    if (skipReason != null) {
+      return;
+    }
+
+    spawnJniForDesktopTests();
     key = await HkdfSecretKey.importRawKey(const [1, 2, 3, 4]);
   });
 
@@ -45,7 +54,7 @@ void main() {
       );
 
       expect(derived, hasLength(maxLengthInBytes));
-    });
+    }, skip: skipReason);
 
     test('$name rejects output one byte beyond the maximum', () async {
       await expectLater(
@@ -58,7 +67,7 @@ void main() {
           ),
         ),
       );
-    });
+    }, skip: skipReason);
   }
 
   test(
@@ -75,5 +84,6 @@ void main() {
         ),
       );
     },
+    skip: skipReason,
   );
 }

--- a/test/rsa_jwk_validation_test.dart
+++ b/test/rsa_jwk_validation_test.dart
@@ -15,14 +15,23 @@
 import 'package:test/test.dart';
 import 'package:webcrypto/webcrypto.dart';
 
+import 'src/jni_test_setup.dart'
+    if (dart.library.io) 'src/jni_test_setup_io.dart';
+
 final _throwsInvalidJwk = throwsA(
   anyOf(isA<FormatException>(), isA<ArgumentError>()),
 );
 
 void main() {
+  final skipReason = jniHelperSetupSkipReason;
   late Map<String, dynamic> privateJwk;
 
   setUpAll(() async {
+    if (skipReason != null) {
+      return;
+    }
+
+    spawnJniForDesktopTests();
     final pair = await RsaOaepPrivateKey.generateKey(
       1024,
       BigInt.from(65537),
@@ -36,7 +45,7 @@ void main() {
       RsaOaepPublicKey.importJsonWebKey(privateJwk, Hash.sha256),
       _throwsInvalidJwk,
     );
-  });
+  }, skip: skipReason);
 
   test('RSA-PSS public import rejects a private JWK', () async {
     await expectLater(
@@ -47,7 +56,7 @@ void main() {
       }, Hash.sha256),
       _throwsInvalidJwk,
     );
-  });
+  }, skip: skipReason);
 
   test('RSASSA-PKCS1-v1_5 public import rejects a private JWK', () async {
     await expectLater(
@@ -58,5 +67,5 @@ void main() {
       }, Hash.sha256),
       _throwsInvalidJwk,
     );
-  });
+  }, skip: skipReason);
 }


### PR DESCRIPTION
## Summary

- Start desktop JNI in `test/hkdf_output_length_test.dart` and `test/rsa_jwk_validation_test.dart`.
- Use the existing prerequisite-aware `skip:` pattern when `dart run jni:setup` has not built the JNI helper library.
- Preserve the public assertions added by #333 and #350.

## Root Cause

The temporary conditional import on `android-jca-branch` routes both standalone VM tests through JNI. `dart run jni:setup` builds the helper library but does not start a JVM in the test process, and neither test called the existing conditional `spawnJniForDesktopTests()` helper.

Android keeps using its platform JVM. This test wiring does not define the production backend selector.

## Testimng

Desktop JNI setup, if needed:

- `dart run jni:setup`

Verified with:

- `dart format --output=none --set-exit-if-changed test/hkdf_output_length_test.dart test/rsa_jwk_validation_test.dart`
- `git diff --check`
- `dart analyze test/hkdf_output_length_test.dart test/rsa_jwk_validation_test.dart`
- `dart test test/hkdf_output_length_test.dart`

Note: All 9 HKDF cases pass. `dart test test/rsa_jwk_validation_test.dart` now executes all 3 RSA cases through JNI, and each currently fails because the separate JNI JWK-validation fix #376  has not landed. After that PR lands, should rebase this branch and require all 3 RSA cases to pass before this PR could be marked as ready for review.
