### PR TITLE
fix(jwk): parse JSON-decoded RSA oth entries

### DIFF
--- a/lib/src/jsonwebkey.dart
+++ b/lib/src/jsonwebkey.dart
@@ -104,8 +104,8 @@ final class JsonWebKey {
       if (json['oth'] is! List || (json['oth'] as List).any((e) => e is! Map)) {
         throw FormatException('JWK entry "oth" must be list of maps', json);
       }
-      oth = (json['oth'] as List<Map>).map((json) {
-        return RsaOtherPrimesInfo.fromJson(json);
+      oth = (json['oth'] as List).map((json) {
+        return RsaOtherPrimesInfo.fromJson(json as Map);
       }).toList();
     }
     return JsonWebKey(

--- a/test/jsonwebkey_test.dart
+++ b/test/jsonwebkey_test.dart
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:test/test.dart';
+import 'package:webcrypto/src/jsonwebkey.dart';
+
+void main() {
+  group('JsonWebKey.fromJson', () {
+    for (final oth in [
+      [
+        {'r': 'prime-1', 'd': 'exponent-1', 't': 'coefficient-1'},
+      ],
+      [
+        {'r': 'prime-1', 'd': 'exponent-1', 't': 'coefficient-1'},
+        {'r': 'prime-2', 'd': 'exponent-2', 't': 'coefficient-2'},
+      ],
+    ]) {
+      test('parses ${oth.length} JSON-decoded other-prime entries', () {
+        final decoded = jsonDecode(jsonEncode({'kty': 'RSA', 'oth': oth}));
+
+        final jwk = JsonWebKey.fromJson(decoded as Map<String, dynamic>);
+
+        expect(jwk.toJson(), {'kty': 'RSA', 'oth': oth});
+      });
+    }
+
+    test('rejects a non-list oth value', () {
+      expect(
+        () => JsonWebKey.fromJson({'oth': 'invalid'}),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects non-map oth entries', () {
+      expect(
+        () => JsonWebKey.fromJson({
+          'oth': ['invalid'],
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    for (final requiredProperty in ['r', 'd', 't']) {
+      test('rejects oth entries without $requiredProperty', () {
+        final oth = {'r': 'prime', 'd': 'exponent', 't': 'coefficient'}
+          ..remove(requiredProperty);
+
+        expect(
+          () => JsonWebKey.fromJson({
+            'oth': [oth],
+          }),
+          throwsA(isA<FormatException>()),
+        );
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- parse JSON-decoded RSA `oth` entries without casting the full `List<dynamic>` to `List<Map>`
- preserve the existing list, map, and required-property validation behavior
- add regression coverage for one and multiple entries plus malformed `oth` values

## Verification

- `dart analyze --fatal-warnings .`
- `dart test -p vm test/jsonwebkey_test.dart`
- `dart test -p chrome test/jsonwebkey_test.dart`
- `dart test -p chrome --compiler dart2wasm test/jsonwebkey_test.dart`
- `dart test -p vm` (1,466 passed, 1 platform-specific test skipped)

Fixes #381
