### PR TITLE
fix(aes-gcm): validate browser tag lengths

### DIFF
--- a/lib/src/impl_js/impl_js.aesgcm.dart
+++ b/lib/src/impl_js/impl_js.aesgcm.dart
@@ -18,6 +18,18 @@ part of 'impl_js.dart';
 
 const _aesGcmAlgorithm = subtle.Algorithm(name: 'AES-GCM');
 
+void _checkAesGcmTagLength(int tagLength) {
+  if (tagLength != 32 &&
+      tagLength != 64 &&
+      tagLength != 96 &&
+      tagLength != 104 &&
+      tagLength != 112 &&
+      tagLength != 120 &&
+      tagLength != 128) {
+    throw operationError('tagLength must be 32, 64, 96, 104, 112, 120 or 128');
+  }
+}
+
 Future<AesGcmSecretKeyImpl> aesGcm_importRawKey(List<int> keyData) async {
   return _AesGcmSecretKeyImpl(
     await _importKey(
@@ -89,6 +101,7 @@ final class _AesGcmSecretKeyImpl implements AesGcmSecretKeyImpl {
     int? tagLength = 128,
   }) async {
     tagLength ??= 128;
+    _checkAesGcmTagLength(tagLength);
     return await _decrypt(
       additionalData == null
           ? _aesGcmAlgorithm.update(
@@ -113,6 +126,7 @@ final class _AesGcmSecretKeyImpl implements AesGcmSecretKeyImpl {
     int? tagLength = 128,
   }) async {
     tagLength ??= 128;
+    _checkAesGcmTagLength(tagLength);
     return await _encrypt(
       additionalData == null
           ? _aesGcmAlgorithm.update(

--- a/lib/src/testing/regression/aes_gcm_invalid_tag_length.dart
+++ b/lib/src/testing/regression/aes_gcm_invalid_tag_length.dart
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:webcrypto/webcrypto.dart';
+import '../utils/utils.dart';
+
+void main() => tests().runTests();
+
+List<({String name, Future<void> Function() test})> tests() => [
+  (
+    name: 'AES-GCM rejects out-of-range tag lengths',
+    test: () async {
+      final key = await AesGcmSecretKey.importRawKey(List.filled(16, 0));
+      final iv = List.generate(12, (i) => i);
+      const plaintext = [1, 2, 3];
+      final ciphertext = await key.encryptBytes(plaintext, iv);
+
+      for (final tagLength in [-128, 384]) {
+        await _expectOperationError(
+          () => key.encryptBytes(plaintext, iv, tagLength: tagLength),
+          'Expected encryption with tagLength $tagLength to be rejected',
+        );
+        await _expectOperationError(
+          () => key.decryptBytes(ciphertext, iv, tagLength: tagLength),
+          'Expected decryption with tagLength $tagLength to be rejected',
+        );
+      }
+    },
+  ),
+];
+
+Future<void> _expectOperationError(
+  Future<Object?> Function() callback,
+  String message,
+) async {
+  try {
+    await callback();
+  } on OperationError {
+    return;
+  }
+  check(false, message);
+}

--- a/lib/src/testing/testing.dart
+++ b/lib/src/testing/testing.dart
@@ -30,6 +30,8 @@ import 'webcrypto/rsassapkcs1v15.dart' as rsassapkcs1v15;
 // Other test files, that don't use TestRunner
 import 'webcrypto/random.dart' as random;
 import 'webcrypto/digest.dart' as digest;
+import 'regression/aes_gcm_invalid_tag_length.dart'
+    as aes_gcm_invalid_tag_length;
 import 'regression/derive_bits_zero_length.dart' as derive_bits_zero_length;
 import 'regression/issue_60_trailing_bytes.dart' as issue_60_trailing_bytes;
 import 'regression/jwk_base64url.dart' as jwk_base64url;
@@ -62,6 +64,7 @@ void runAllTests(
     for (final r in _testRunners) ...r.tests(),
     ...random.tests(),
     ...digest.tests(),
+    ...aes_gcm_invalid_tag_length.tests(),
     ...issue_60_trailing_bytes.tests(),
     ...jwk_base64url.tests(),
     ...derive_bits_zero_length.tests(),


### PR DESCRIPTION
## Summary

- validate AES-GCM tag lengths in the browser backend before Web Crypto conversion
- return `OperationError` for invalid values, matching the native backend
- cover encryption and decryption through the shared cross-backend test harness

Fixes #384

## Testing

- `dart format lib/src/impl_js/impl_js.aesgcm.dart lib/src/testing/regression/aes_gcm_invalid_tag_length.dart lib/src/testing/testing.dart`
- `dart analyze --fatal-warnings .`
- `dart test -p vm` (1,460 passed, 1 existing skip)
- `dart test test/webcrypto_test.dart -p chrome -c dart2js` (1,441 passed)
- `dart test test/webcrypto_test.dart -p chrome -c dart2wasm` (1,441 passed)

Firefox was not available locally; the repository CI browser matrix provides that coverage.
