### PR TITLE
fix(rsa): validate modulus length before browser interop

### DIFF
--- a/lib/src/testing/regression/rsa_modulus_length.dart
+++ b/lib/src/testing/regression/rsa_modulus_length.dart
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:webcrypto/webcrypto.dart';
+
+import '../utils/utils.dart';
+
+final _rsaKeyGenerators = <String, Future<void> Function(int)>{
+  'RSA-OAEP': (modulusLength) async {
+    await RsaOaepPrivateKey.generateKey(
+      modulusLength,
+      BigInt.from(65537),
+      Hash.sha256,
+    );
+  },
+  'RSA-PSS': (modulusLength) async {
+    await RsaPssPrivateKey.generateKey(
+      modulusLength,
+      BigInt.from(65537),
+      Hash.sha256,
+    );
+  },
+  'RSASSA-PKCS1-v1_5': (modulusLength) async {
+    await RsassaPkcs1V15PrivateKey.generateKey(
+      modulusLength,
+      BigInt.from(65537),
+      Hash.sha256,
+    );
+  },
+};
+
+List<({String name, Future<void> Function() test})> tests() => [
+  for (final MapEntry(key: algorithm, value: generateKey)
+      in _rsaKeyGenerators.entries)
+    for (final modulusLength in [-1, 0x100000000])
+      (
+        name: '$algorithm rejects modulusLength $modulusLength',
+        test: () async {
+          Object? error;
+          try {
+            await generateKey(modulusLength);
+          } catch (e) {
+            error = e;
+          }
+          check(
+            error is ArgumentError,
+            'Expected ArgumentError for modulusLength $modulusLength, '
+            'got $error',
+          );
+        },
+      ),
+];

--- a/lib/src/testing/testing.dart
+++ b/lib/src/testing/testing.dart
@@ -34,6 +34,7 @@ import 'regression/derive_bits_zero_length.dart' as derive_bits_zero_length;
 import 'regression/issue_60_trailing_bytes.dart' as issue_60_trailing_bytes;
 import 'regression/jwk_base64url.dart' as jwk_base64url;
 import 'regression/rsa_oaep_sha1_jwk_alg.dart' as rsa_oaep_sha1_jwk_alg;
+import 'regression/rsa_modulus_length.dart' as rsa_modulus_length;
 
 /// Test runners from all test files except `digest.dart` and
 /// `random.dart`, which do not use [TestRunner].
@@ -66,6 +67,7 @@ void runAllTests(
     ...jwk_base64url.tests(),
     ...derive_bits_zero_length.tests(),
     ...rsa_oaep_sha1_jwk_alg.tests(),
+    ...rsa_modulus_length.tests(),
   ];
 
   for (final (:name, :test) in allTests) {

--- a/lib/src/webcrypto/webcrypto.dart
+++ b/lib/src/webcrypto/webcrypto.dart
@@ -45,3 +45,13 @@ part 'webcrypto.random.dart';
 part 'webcrypto.rsaoaep.dart';
 part 'webcrypto.rsapss.dart';
 part 'webcrypto.rsassapkcs1v15.dart';
+
+void _checkRsaModulusLength(int modulusLength) {
+  if (modulusLength < 0 || modulusLength > 0xffffffff) {
+    throw ArgumentError.value(
+      modulusLength,
+      'modulusLength',
+      'must be between 0 and 2^32 - 1',
+    );
+  }
+}

--- a/lib/src/webcrypto/webcrypto.rsaoaep.dart
+++ b/lib/src/webcrypto/webcrypto.rsaoaep.dart
@@ -249,6 +249,7 @@ final class RsaOaepPrivateKey {
     BigInt publicExponent,
     Hash hash,
   ) async {
+    _checkRsaModulusLength(modulusLength);
     final (privateKeyImpl, publicKeyImpl) = await webCryptImpl.rsaOaepPrivateKey
         .generateKey(modulusLength, publicExponent, hash._impl);
 

--- a/lib/src/webcrypto/webcrypto.rsapss.dart
+++ b/lib/src/webcrypto/webcrypto.rsapss.dart
@@ -229,6 +229,7 @@ final class RsaPssPrivateKey {
     BigInt publicExponent,
     Hash hash,
   ) async {
+    _checkRsaModulusLength(modulusLength);
     final (privateKeyImpl, publicKeyImpl) = await webCryptImpl.rsaPssPrivateKey
         .generateKey(modulusLength, publicExponent, hash._impl);
 

--- a/lib/src/webcrypto/webcrypto.rsassapkcs1v15.dart
+++ b/lib/src/webcrypto/webcrypto.rsassapkcs1v15.dart
@@ -257,6 +257,7 @@ final class RsassaPkcs1V15PrivateKey {
   /// ```
   static Future<KeyPair<RsassaPkcs1V15PrivateKey, RsassaPkcs1V15PublicKey>>
   generateKey(int modulusLength, BigInt publicExponent, Hash hash) async {
+    _checkRsaModulusLength(modulusLength);
     final (privateKeyImpl, publicKeyImpl) = await webCryptImpl
         .rsaSsaPkcs1v15PrivateKey
         .generateKey(modulusLength, publicExponent, hash._impl);


### PR DESCRIPTION
## Summary

- validate RSA `modulusLength` against the WebIDL unsigned-long range before backend dispatch
- apply the shared validation to RSA-OAEP, RSA-PSS, and RSASSA-PKCS1-v1_5 key generation
- add cross-backend regression coverage for negative and overflowing values

## Motivation

The browser backend previously forwarded out-of-range `modulusLength` values to `SubtleCrypto.generateKey`. WebIDL conversion failures then escaped through Dart2JS as raw `JSObject: TypeError` values.

Validating at the shared public API boundary produces a consistent Dart `ArgumentError` before browser interop and avoids duplicating checks in individual backends.

## Testing

- `dart analyze --fatal-warnings .`
- `dart test test/webcrypto_test.dart -p vm`
- `dart test test/webcrypto_test.dart -p chrome -c dart2js`
- `dart test test/webcrypto_test.dart -p chrome -c dart2wasm`
- `dart format --output=none --set-exit-if-changed` on all changed Dart files
- `git diff --check`

Fixes #387
