### PR TITLE
fix(kdf): validate deriveBits output length

### DIFF
--- a/lib/src/testing/regression/kdf_invalid_length.dart
+++ b/lib/src/testing/regression/kdf_invalid_length.dart
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:webcrypto/webcrypto.dart';
+
+import '../utils/utils.dart';
+
+List<({String name, Future<void> Function() test})> tests() => [
+  (
+    name: 'PBKDF2 rejects lengths outside the Web IDL unsigned long range',
+    test: () async {
+      final key = await Pbkdf2SecretKey.importRawKey([1]);
+      for (final length in [-0xfffffff8, 0x100000008]) {
+        await _expectArgumentError(key.deriveBits(length, Hash.sha256, [2], 1));
+      }
+    },
+  ),
+  (
+    name: 'HKDF rejects lengths outside the Web IDL unsigned long range',
+    test: () async {
+      final key = await HkdfSecretKey.importRawKey([1]);
+      for (final length in [-0xfffffff8, 0x100000008]) {
+        await _expectArgumentError(
+          key.deriveBits(length, Hash.sha256, [2], [3]),
+        );
+      }
+    },
+  ),
+];
+
+Future<void> _expectArgumentError(Future<List<int>> operation) async {
+  var threw = false;
+  try {
+    await operation;
+  } on ArgumentError {
+    threw = true;
+  }
+  check(threw, 'Expected ArgumentError for invalid deriveBits length');
+}

--- a/lib/src/testing/testing.dart
+++ b/lib/src/testing/testing.dart
@@ -36,6 +36,7 @@ import 'regression/derive_bits_zero_length.dart' as derive_bits_zero_length;
 import 'regression/ecdh_invalid_length.dart' as ecdh_invalid_length;
 import 'regression/issue_60_trailing_bytes.dart' as issue_60_trailing_bytes;
 import 'regression/jwk_base64url.dart' as jwk_base64url;
+import 'regression/kdf_invalid_length.dart' as kdf_invalid_length;
 import 'regression/rsa_oaep_sha1_jwk_alg.dart' as rsa_oaep_sha1_jwk_alg;
 import 'regression/rsa_modulus_length.dart' as rsa_modulus_length;
 
@@ -71,6 +72,7 @@ void runAllTests(
     ...jwk_base64url.tests(),
     ...derive_bits_zero_length.tests(),
     ...ecdh_invalid_length.tests(),
+    ...kdf_invalid_length.tests(),
     ...rsa_oaep_sha1_jwk_alg.tests(),
     ...rsa_modulus_length.tests(),
   ];

--- a/lib/src/webcrypto/webcrypto.dart
+++ b/lib/src/webcrypto/webcrypto.dart
@@ -55,3 +55,13 @@ void _checkRsaModulusLength(int modulusLength) {
     );
   }
 }
+
+void _checkDeriveBitsLength(int length) {
+  if (length < 0 || length > 0xffffffff) {
+    throw ArgumentError.value(
+      length,
+      'length',
+      'must be between 0 and 2^32 - 1',
+    );
+  }
+}

--- a/lib/src/webcrypto/webcrypto.hkdf.dart
+++ b/lib/src/webcrypto/webcrypto.hkdf.dart
@@ -91,5 +91,8 @@ final class HkdfSecretKey {
     Hash hash,
     List<int> salt,
     List<int> info,
-  ) => _impl.deriveBits(length, hash._impl, salt, info);
+  ) async {
+    _checkDeriveBitsLength(length);
+    return await _impl.deriveBits(length, hash._impl, salt, info);
+  }
 }

--- a/lib/src/webcrypto/webcrypto.pbkdf2.dart
+++ b/lib/src/webcrypto/webcrypto.pbkdf2.dart
@@ -91,5 +91,8 @@ final class Pbkdf2SecretKey {
     Hash hash,
     List<int> salt,
     int iterations,
-  ) => _impl.deriveBits(length, hash._impl, salt, iterations);
+  ) async {
+    _checkDeriveBitsLength(length);
+    return await _impl.deriveBits(length, hash._impl, salt, iterations);
+  }
 }


### PR DESCRIPTION
Fixes #389.

## Summary

- validate HKDF and PBKDF2 `deriveBits` lengths before backend dispatch
- reject values outside the Web IDL `unsigned long` range
- add shared regression coverage for negative and greater-than-32-bit values

## Root cause

The browser backend forwarded arbitrary Dart integers to `SubtleCrypto.deriveBits`. Web IDL converted those values to `unsigned long`, so inputs such as `-0xfffffff8` wrapped to `8` and produced a one-byte result instead of failing.

The shared validation also prevents oversized PBKDF2 output lengths from reaching the native allocation path.

## Validation

- `dart analyze --fatal-warnings .`
- focused regression on VM
- focused regression on Chrome with dart2js
- focused regression on Chrome with dart2wasm
- broader HKDF/PBKDF2 shared suite on VM
- broader HKDF/PBKDF2 shared suite on Chrome with dart2js
- broader HKDF/PBKDF2 shared suite on Chrome with dart2wasm
- `git diff --check`
