### PR TITLE
fix(aes-ctr): validate browser counter lengths

### DIFF
--- a/lib/src/impl_js/impl_js.aesctr.dart
+++ b/lib/src/impl_js/impl_js.aesctr.dart
@@ -18,6 +18,12 @@ part of 'impl_js.dart';
 
 const _aesCtrAlgorithm = subtle.Algorithm(name: 'AES-CTR');
 
+void _checkAesCtrLength(int length) {
+  if (length <= 0 || 128 < length) {
+    throw ArgumentError.value(length, 'length', 'must be between 1 and 128');
+  }
+}
+
 Future<AesCtrSecretKeyImpl> aesCtr_importRawKey(List<int> keyData) async {
   return _AesCtrSecretKeyImpl(
     await _importKey(
@@ -87,6 +93,7 @@ final class _AesCtrSecretKeyImpl implements AesCtrSecretKeyImpl {
     List<int> counter,
     int length,
   ) async {
+    _checkAesCtrLength(length);
     return await _decrypt(
       _aesCtrAlgorithm.update(
         counter: Uint8List.fromList(counter),
@@ -112,6 +119,7 @@ final class _AesCtrSecretKeyImpl implements AesCtrSecretKeyImpl {
     List<int> counter,
     int length,
   ) async {
+    _checkAesCtrLength(length);
     return await _encrypt(
       _aesCtrAlgorithm.update(
         counter: Uint8List.fromList(counter),

--- a/lib/src/testing/regression/aes_ctr_invalid_length.dart
+++ b/lib/src/testing/regression/aes_ctr_invalid_length.dart
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:webcrypto/webcrypto.dart';
+
+import '../utils/utils.dart';
+
+List<({String name, Future<void> Function() test})> tests() => [
+  (
+    name: 'AES-CTR rejects invalid counter lengths',
+    test: () async {
+      final key = await AesCtrSecretKey.importRawKey(List.filled(16, 0));
+      final counter = List.filled(16, 0);
+      const plaintext = [1, 2, 3];
+      final ciphertext = await key.encryptBytes(plaintext, counter, 128);
+
+      for (final length in [-1, 0, 129, 256]) {
+        await _expectArgumentError(
+          () => key.encryptBytes(plaintext, counter, length),
+          length,
+        );
+        await _expectArgumentError(
+          () => key.decryptBytes(ciphertext, counter, length),
+          length,
+        );
+      }
+    },
+  ),
+];
+
+Future<void> _expectArgumentError(
+  Future<Object?> Function() callback,
+  int length,
+) async {
+  Object? error;
+  try {
+    await callback();
+  } catch (e) {
+    error = e;
+  }
+  check(
+    error is ArgumentError,
+    'Expected ArgumentError for AES-CTR length $length, got $error',
+  );
+}

--- a/lib/src/testing/testing.dart
+++ b/lib/src/testing/testing.dart
@@ -30,6 +30,7 @@ import 'webcrypto/rsassapkcs1v15.dart' as rsassapkcs1v15;
 // Other test files, that don't use TestRunner
 import 'webcrypto/random.dart' as random;
 import 'webcrypto/digest.dart' as digest;
+import 'regression/aes_ctr_invalid_length.dart' as aes_ctr_invalid_length;
 import 'regression/issue_302_hmac_jwk_length.dart' as issue_302_hmac_jwk_length;
 import 'regression/aes_gcm_invalid_tag_length.dart'
     as aes_gcm_invalid_tag_length;
@@ -67,6 +68,7 @@ void runAllTests(
     for (final r in _testRunners) ...r.tests(),
     ...random.tests(),
     ...digest.tests(),
+    ...aes_ctr_invalid_length.tests(),
     ...issue_302_hmac_jwk_length.tests(),
     ...aes_gcm_invalid_tag_length.tests(),
     ...issue_60_trailing_bytes.tests(),


### PR DESCRIPTION
## Summary

- validate AES-CTR counter bit lengths before browser interop
- align browser errors with the native backend
- add cross-backend regression coverage for invalid lengths

Fixes #392

## Testing

- `dart analyze --fatal-warnings`
- `dart test -p vm`
- `dart test -p chrome test/webcrypto_test.dart`
- `dart test -p chrome --compiler dart2wasm test/webcrypto_test.dart`
