### PR TITLE
fix: normalize use in browser JWK exports

### DIFF
--- a/lib/src/impl_js/impl_js.aescbc.dart
+++ b/lib/src/impl_js/impl_js.aescbc.dart
@@ -111,7 +111,7 @@ final class _AesCbcSecretKeyImpl implements AesCbcSecretKeyImpl {
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: 'enc');
   }
 
   @override

--- a/lib/src/impl_js/impl_js.aesctr.dart
+++ b/lib/src/impl_js/impl_js.aesctr.dart
@@ -133,7 +133,7 @@ final class _AesCtrSecretKeyImpl implements AesCtrSecretKeyImpl {
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: 'enc');
   }
 
   @override

--- a/lib/src/impl_js/impl_js.aesgcm.dart
+++ b/lib/src/impl_js/impl_js.aesgcm.dart
@@ -145,7 +145,7 @@ final class _AesGcmSecretKeyImpl implements AesGcmSecretKeyImpl {
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: 'enc');
   }
 
   @override

--- a/lib/src/impl_js/impl_js.ecdh.dart
+++ b/lib/src/impl_js/impl_js.ecdh.dart
@@ -214,7 +214,7 @@ final class _EcdhPrivateKeyImpl implements EcdhPrivateKeyImpl {
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: null);
   }
 
   @override
@@ -256,7 +256,7 @@ final class _EcdhPublicKeyImpl implements EcdhPublicKeyImpl {
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: null);
   }
 
   @override

--- a/lib/src/impl_js/impl_js.ecdsa.dart
+++ b/lib/src/impl_js/impl_js.ecdsa.dart
@@ -175,7 +175,7 @@ final class _EcdsaPrivateKeyImpl implements EcdsaPrivateKeyImpl {
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: 'sig');
   }
 
   @override
@@ -243,7 +243,7 @@ final class _EcdsaPublicKeyImpl implements EcdsaPublicKeyImpl {
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: 'sig');
   }
 
   @override

--- a/lib/src/impl_js/impl_js.hmac.dart
+++ b/lib/src/impl_js/impl_js.hmac.dart
@@ -170,7 +170,7 @@ final class _HmacSecretKeyImpl implements HmacSecretKeyImpl {
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: 'sig');
   }
 
   @override

--- a/lib/src/impl_js/impl_js.rsaoaep.dart
+++ b/lib/src/impl_js/impl_js.rsaoaep.dart
@@ -171,7 +171,7 @@ final class _RsaOaepPrivateKeyImpl implements RsaOaepPrivateKeyImpl {
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: 'enc');
   }
 
   @override
@@ -222,7 +222,7 @@ final class _RsaOaepPublicKeyImpl implements RsaOaepPublicKeyImpl {
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: 'enc');
   }
 
   @override

--- a/lib/src/impl_js/impl_js.rsapss.dart
+++ b/lib/src/impl_js/impl_js.rsapss.dart
@@ -174,7 +174,7 @@ final class _RsaPssPrivateKeyImpl implements RsaPssPrivateKeyImpl {
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: 'sig');
   }
 
   @override
@@ -245,7 +245,7 @@ final class _RsaPssPublicKeyImpl implements RsaPssPublicKeyImpl {
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: 'sig');
   }
 
   @override

--- a/lib/src/impl_js/impl_js.rsassapkcs1v15.dart
+++ b/lib/src/impl_js/impl_js.rsassapkcs1v15.dart
@@ -147,7 +147,7 @@ final class _RsaSsaPkcs1V15PrivateKeyImpl
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: 'sig');
   }
 
   @override
@@ -199,7 +199,7 @@ final class _RsaSsaPkcs1V15PublicKeyImpl
 
   @override
   Future<Map<String, dynamic>> exportJsonWebKey() async {
-    return await _exportJsonWebKey(_key);
+    return await _exportJsonWebKey(_key, jwkUse: 'sig');
   }
 
   @override

--- a/lib/src/impl_js/impl_js.utils.dart
+++ b/lib/src/impl_js/impl_js.utils.dart
@@ -295,9 +295,9 @@ Future<Uint8List> _exportKey(String format, subtle.JSCryptoKey key) {
 
 /// Adapt `crypto.subtle.export` to Dart types.
 Future<Map<String, Object>> _exportJsonWebKey(
-  subtle.JSCryptoKey key,
-  // TODO: Add expected 'use' the way we have it in the FFI implementation
-) {
+  subtle.JSCryptoKey key, {
+  required String? jwkUse,
+}) {
   return _handleDomException(() async {
     final jwk = await subtle.exportJsonWebKey('jwk', key);
     // Remove 'key_ops' and 'ext' as this library doesn't allow configuration of
@@ -305,6 +305,7 @@ Future<Map<String, Object>> _exportJsonWebKey(
     // Notice, that we also strip these in [_importJsonWebKey].
     jwk.key_ops = null;
     jwk.ext = null;
+    jwk.use = jwkUse;
     return jwk.toJson();
   });
 }

--- a/lib/src/testing/regression/jwk_export_use.dart
+++ b/lib/src/testing/regression/jwk_export_use.dart
@@ -1,0 +1,149 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:webcrypto/webcrypto.dart';
+
+import '../utils/utils.dart';
+
+void main() => tests().runTests();
+
+List<({String name, Future<void> Function() test})> tests() => [
+  (
+    name: 'JWK exports include consistent use metadata',
+    test: () async {
+      final aesKeyData = List<int>.filled(16, 0);
+      await _expectUse(
+        (await AesCbcSecretKey.importRawKey(aesKeyData)).exportJsonWebKey(),
+        'enc',
+        'AES-CBC',
+      );
+      await _expectUse(
+        (await AesCtrSecretKey.importRawKey(aesKeyData)).exportJsonWebKey(),
+        'enc',
+        'AES-CTR',
+      );
+      await _expectUse(
+        (await AesGcmSecretKey.importRawKey(aesKeyData)).exportJsonWebKey(),
+        'enc',
+        'AES-GCM',
+      );
+      await _expectUse(
+        (await HmacSecretKey.importRawKey(
+          List<int>.filled(32, 0),
+          Hash.sha256,
+        )).exportJsonWebKey(),
+        'sig',
+        'HMAC',
+      );
+
+      final ecdsaKeyPair = await EcdsaPrivateKey.generateKey(
+        EllipticCurve.p256,
+      );
+      await _expectUse(
+        ecdsaKeyPair.privateKey.exportJsonWebKey(),
+        'sig',
+        'ECDSA private key',
+      );
+      await _expectUse(
+        ecdsaKeyPair.publicKey.exportJsonWebKey(),
+        'sig',
+        'ECDSA public key',
+      );
+
+      final ecdhKeyPair = await EcdhPrivateKey.generateKey(EllipticCurve.p256);
+      await _expectUse(
+        ecdhKeyPair.privateKey.exportJsonWebKey(),
+        null,
+        'ECDH private key',
+      );
+      await _expectUse(
+        ecdhKeyPair.publicKey.exportJsonWebKey(),
+        null,
+        'ECDH public key',
+      );
+
+      final rsaOaepKeyPair = await RsaOaepPrivateKey.generateKey(
+        2048,
+        BigInt.from(65537),
+        Hash.sha256,
+      );
+      await _expectUse(
+        rsaOaepKeyPair.privateKey.exportJsonWebKey(),
+        'enc',
+        'RSA-OAEP private key',
+      );
+      await _expectUse(
+        rsaOaepKeyPair.publicKey.exportJsonWebKey(),
+        'enc',
+        'RSA-OAEP public key',
+      );
+
+      final pkcs8 = await rsaOaepKeyPair.privateKey.exportPkcs8Key();
+      final spki = await rsaOaepKeyPair.publicKey.exportSpkiKey();
+      final rsaPssPrivateKey = await RsaPssPrivateKey.importPkcs8Key(
+        pkcs8,
+        Hash.sha256,
+      );
+      final rsaPssPublicKey = await RsaPssPublicKey.importSpkiKey(
+        spki,
+        Hash.sha256,
+      );
+      await _expectUse(
+        rsaPssPrivateKey.exportJsonWebKey(),
+        'sig',
+        'RSA-PSS private key',
+      );
+      await _expectUse(
+        rsaPssPublicKey.exportJsonWebKey(),
+        'sig',
+        'RSA-PSS public key',
+      );
+
+      final rsaSsaPrivateKey = await RsassaPkcs1V15PrivateKey.importPkcs8Key(
+        pkcs8,
+        Hash.sha256,
+      );
+      final rsaSsaPublicKey = await RsassaPkcs1V15PublicKey.importSpkiKey(
+        spki,
+        Hash.sha256,
+      );
+      await _expectUse(
+        rsaSsaPrivateKey.exportJsonWebKey(),
+        'sig',
+        'RSASSA-PKCS1-v1_5 private key',
+      );
+      await _expectUse(
+        rsaSsaPublicKey.exportJsonWebKey(),
+        'sig',
+        'RSASSA-PKCS1-v1_5 public key',
+      );
+    },
+  ),
+];
+
+Future<void> _expectUse(
+  Future<Map<String, dynamic>> jwk,
+  String? expectedUse,
+  String keyType,
+) async {
+  final value = await jwk;
+  if (expectedUse == null) {
+    check(!value.containsKey('use'), 'Expected $keyType to omit JWK use');
+  } else {
+    check(
+      value['use'] == expectedUse,
+      'Expected $keyType JWK use to be "$expectedUse"',
+    );
+  }
+}

--- a/lib/src/testing/testing.dart
+++ b/lib/src/testing/testing.dart
@@ -37,6 +37,7 @@ import 'regression/derive_bits_zero_length.dart' as derive_bits_zero_length;
 import 'regression/ecdh_invalid_length.dart' as ecdh_invalid_length;
 import 'regression/issue_60_trailing_bytes.dart' as issue_60_trailing_bytes;
 import 'regression/jwk_base64url.dart' as jwk_base64url;
+import 'regression/jwk_export_use.dart' as jwk_export_use;
 import 'regression/rsa_oaep_sha1_jwk_alg.dart' as rsa_oaep_sha1_jwk_alg;
 import 'regression/rsa_modulus_length.dart' as rsa_modulus_length;
 
@@ -71,6 +72,7 @@ void runAllTests(
     ...aes_gcm_invalid_tag_length.tests(),
     ...issue_60_trailing_bytes.tests(),
     ...jwk_base64url.tests(),
+    ...jwk_export_use.tests(),
     ...derive_bits_zero_length.tests(),
     ...ecdh_invalid_length.tests(),
     ...rsa_oaep_sha1_jwk_alg.tests(),

--- a/test/wrap_key_equivalence_test.dart
+++ b/test/wrap_key_equivalence_test.dart
@@ -395,7 +395,7 @@ void main() {
     );
 
     test(
-      'JWK wrapKey carries ext/key_ops metadata that package exportJsonWebKey omits',
+      'JWK package export normalizes use and omits ext/key_ops metadata',
       () async {
         final jsWrapped = await _wrapKey(
           wrap,
@@ -438,13 +438,17 @@ void main() {
 
         expect(jsJwk['ext'], isTrue);
         expect(jsJwk['key_ops'], orderedEquals(['sign', 'verify']));
+        expect(jsJwk.containsKey('use'), isFalse);
         expect(packageJwk.containsKey('ext'), isFalse);
         expect(packageJwk.containsKey('key_ops'), isFalse);
+        expect(packageJwk['use'], 'sig');
 
         final normalizedJsJwk = Map<String, dynamic>.from(jsJwk)
           ..remove('ext')
           ..remove('key_ops');
-        expect(normalizedJsJwk, equals(packageJwk));
+        final normalizedPackageJwk = Map<String, dynamic>.from(packageJwk)
+          ..remove('use');
+        expect(normalizedJsJwk, equals(normalizedPackageJwk));
       },
     );
   });


### PR DESCRIPTION
Fixes #399.

## Summary

- normalize algorithm-appropriate `use` metadata in browser JWK exports
- emit `enc` for encryption keys and `sig` for signing keys
- preserve omitted `use` for ECDH and omitted `key_ops` and `ext`
- add regression coverage for every supported JWK-exporting algorithm

## Testing

- `dart format --output none --set-exit-if-changed lib/src test`
- `dart analyze --fatal-warnings .`
- `dart test --exclude-tags browser-interop -p vm`
- `dart test --exclude-tags browser-interop -p chrome -c dart2js`
- `dart test --exclude-tags browser-interop -p chrome -c dart2wasm --concurrency=1`
- `dart test -p chrome -c dart2js test/wrap_key_equivalence_test.dart`
- `dart test -p chrome -c dart2wasm test/wrap_key_equivalence_test.dart`