### PR TITLE
fix(rsapss): deliver validation errors through Futures

### DIFF
--- a/lib/src/testing/regression/rsa_pss_async_errors.dart
+++ b/lib/src/testing/regression/rsa_pss_async_errors.dart
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:webcrypto/webcrypto.dart';
+
+import '../utils/utils.dart';
+
+List<({String name, Future<void> Function() test})> tests() => [
+  (
+    name: 'RSA-PSS reports invalid saltLength through returned Futures',
+    test: () async {
+      final pair = await RsaPssPrivateKey.generateKey(
+        1024,
+        BigInt.from(65537),
+        Hash.sha256,
+      );
+      const data = [1, 2, 3];
+      const signature = <int>[];
+
+      final operations = <String, Future<Object?> Function()>{
+        'signBytes': () => pair.privateKey.signBytes(data, -1),
+        'signStream': () => pair.privateKey.signStream(Stream.value(data), -1),
+        'verifyBytes': () => pair.publicKey.verifyBytes(signature, data, -1),
+        'verifyStream': () =>
+            pair.publicKey.verifyStream(signature, Stream.value(data), -1),
+      };
+
+      for (final MapEntry(key: name, value: operation) in operations.entries) {
+        await _expectAsyncArgumentError(name, operation);
+      }
+    },
+  ),
+];
+
+Future<void> _expectAsyncArgumentError(
+  String name,
+  Future<Object?> Function() operation,
+) async {
+  late Future<Object?> result;
+  try {
+    result = operation();
+  } catch (error) {
+    throw AssertionError('$name threw synchronously: $error');
+  }
+
+  Object? error;
+  try {
+    await result;
+  } catch (e) {
+    error = e;
+  }
+  check(error is ArgumentError, '$name returned $error');
+}

--- a/lib/src/testing/testing.dart
+++ b/lib/src/testing/testing.dart
@@ -39,6 +39,7 @@ import 'regression/issue_60_trailing_bytes.dart' as issue_60_trailing_bytes;
 import 'regression/jwk_base64url.dart' as jwk_base64url;
 import 'regression/rsa_oaep_sha1_jwk_alg.dart' as rsa_oaep_sha1_jwk_alg;
 import 'regression/rsa_modulus_length.dart' as rsa_modulus_length;
+import 'regression/rsa_pss_async_errors.dart' as rsa_pss_async_errors;
 
 /// Test runners from all test files except `digest.dart` and
 /// `random.dart`, which do not use [TestRunner].
@@ -75,6 +76,7 @@ void runAllTests(
     ...ecdh_invalid_length.tests(),
     ...rsa_oaep_sha1_jwk_alg.tests(),
     ...rsa_modulus_length.tests(),
+    ...rsa_pss_async_errors.tests(),
   ];
 
   for (final (:name, :test) in allTests) {

--- a/lib/src/webcrypto/webcrypto.rsapss.dart
+++ b/lib/src/webcrypto/webcrypto.rsapss.dart
@@ -312,8 +312,8 @@ final class RsaPssPrivateKey {
   // Which makes it hard for us to say that it's not useful.
   //
   // Note: Web Cryptography specification references RFC 3447, not FIPS 186-4.
-  Future<Uint8List> signBytes(List<int> data, int saltLength) =>
-      _impl.signBytes(data, saltLength);
+  Future<Uint8List> signBytes(List<int> data, int saltLength) async =>
+      await _impl.signBytes(data, saltLength);
 
   /// Sign [data] with this RSASSA-PSS private key.
   ///
@@ -369,8 +369,8 @@ final class RsaPssPrivateKey {
   ///
   /// [1]: https://www.rfc-editor.org/rfc/rfc3447#section-9.1
   /// [2]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf
-  Future<Uint8List> signStream(Stream<List<int>> data, int saltLength) =>
-      _impl.signStream(data, saltLength);
+  Future<Uint8List> signStream(Stream<List<int>> data, int saltLength) async =>
+      await _impl.signStream(data, saltLength);
 
   /// Export this RSASSA-PSS private key in PKCS #8 format.
   ///
@@ -600,7 +600,7 @@ final class RsaPssPublicKey {
     List<int> signature,
     List<int> data,
     int saltLength,
-  ) => _impl.verifyBytes(signature, data, saltLength);
+  ) async => await _impl.verifyBytes(signature, data, saltLength);
 
   /// Verify [signature] of [data] using this RSASSA-PSS public key.
   ///
@@ -648,7 +648,7 @@ final class RsaPssPublicKey {
     List<int> signature,
     Stream<List<int>> data,
     int saltLength,
-  ) => _impl.verifyStream(signature, data, saltLength);
+  ) async => await _impl.verifyStream(signature, data, saltLength);
 
   /// Export RSASSA-PSS public key in SPKI format.
   ///


### PR DESCRIPTION
## Summary

- ensure RSA-PSS signing and verification report backend validation failures through returned Futures
- cover byte and stream APIs with cross-backend regression tests

Fixes #401

## Testing

- `dart analyze --fatal-warnings .`
- `dart test -p vm test/webcrypto_test.dart`
- `dart test -p chrome test/webcrypto_test.dart`
- `dart test -p chrome --compiler dart2wasm test/webcrypto_test.dart`
