### PR TITLE
fix(aes): validate key generation lengths

### DIFF
--- a/lib/src/testing/regression/aes_key_length.dart
+++ b/lib/src/testing/regression/aes_key_length.dart
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:webcrypto/webcrypto.dart';
+
+import '../utils/utils.dart';
+
+final _aesKeyGenerators = <String, Future<void> Function(int)>{
+  'AES-CBC': (length) async {
+    await AesCbcSecretKey.generateKey(length);
+  },
+  'AES-CTR': (length) async {
+    await AesCtrSecretKey.generateKey(length);
+  },
+  'AES-GCM': (length) async {
+    await AesGcmSecretKey.generateKey(length);
+  },
+};
+
+List<({String name, Future<void> Function() test})> tests() => [
+  for (final MapEntry(key: algorithm, value: generateKey)
+      in _aesKeyGenerators.entries)
+    for (final length in [-1, 64, 0x10000])
+      (
+        name: '$algorithm rejects key length $length',
+        test: () async {
+          Object? error;
+          try {
+            await generateKey(length);
+          } catch (e) {
+            error = e;
+          }
+          check(
+            error is FormatException,
+            'Expected FormatException for key length $length, got $error',
+          );
+        },
+      ),
+  for (final MapEntry(key: algorithm, value: generateKey)
+      in _aesKeyGenerators.entries)
+    (
+      name: '$algorithm rejects unsupported 192-bit keys',
+      test: () async {
+        Object? error;
+        try {
+          await generateKey(192);
+        } catch (e) {
+          error = e;
+        }
+        check(
+          error is UnsupportedError,
+          'Expected UnsupportedError for a 192-bit key, got $error',
+        );
+      },
+    ),
+];

--- a/lib/src/testing/testing.dart
+++ b/lib/src/testing/testing.dart
@@ -30,6 +30,7 @@ import 'webcrypto/rsassapkcs1v15.dart' as rsassapkcs1v15;
 // Other test files, that don't use TestRunner
 import 'webcrypto/random.dart' as random;
 import 'webcrypto/digest.dart' as digest;
+import 'regression/aes_key_length.dart' as aes_key_length;
 import 'regression/issue_302_hmac_jwk_length.dart' as issue_302_hmac_jwk_length;
 import 'regression/aes_gcm_invalid_tag_length.dart'
     as aes_gcm_invalid_tag_length;
@@ -67,6 +68,7 @@ void runAllTests(
     for (final r in _testRunners) ...r.tests(),
     ...random.tests(),
     ...digest.tests(),
+    ...aes_key_length.tests(),
     ...issue_302_hmac_jwk_length.tests(),
     ...aes_gcm_invalid_tag_length.tests(),
     ...issue_60_trailing_bytes.tests(),

--- a/lib/src/webcrypto/webcrypto.aescbc.dart
+++ b/lib/src/webcrypto/webcrypto.aescbc.dart
@@ -139,6 +139,7 @@ final class AesCbcSecretKey {
   /// }
   /// ```
   static Future<AesCbcSecretKey> generateKey(int length) async {
+    _checkAesKeyLength(length);
     final impl = await webCryptImpl.aesCbcSecretKey.generateKey(length);
     return AesCbcSecretKey._(impl);
   }

--- a/lib/src/webcrypto/webcrypto.aesctr.dart
+++ b/lib/src/webcrypto/webcrypto.aesctr.dart
@@ -134,6 +134,7 @@ final class AesCtrSecretKey {
   /// }
   /// ```
   static Future<AesCtrSecretKey> generateKey(int length) async {
+    _checkAesKeyLength(length);
     final impl = await webCryptImpl.aesCtrSecretKey.generateKey(length);
     return AesCtrSecretKey._(impl);
   }

--- a/lib/src/webcrypto/webcrypto.aesgcm.dart
+++ b/lib/src/webcrypto/webcrypto.aesgcm.dart
@@ -134,6 +134,7 @@ final class AesGcmSecretKey {
   /// }
   /// ```
   static Future<AesGcmSecretKey> generateKey(int length) async {
+    _checkAesKeyLength(length);
     final impl = await webCryptImpl.aesGcmSecretKey.generateKey(length);
     return AesGcmSecretKey._(impl);
   }

--- a/lib/src/webcrypto/webcrypto.dart
+++ b/lib/src/webcrypto/webcrypto.dart
@@ -55,3 +55,12 @@ void _checkRsaModulusLength(int modulusLength) {
     );
   }
 }
+
+void _checkAesKeyLength(int length) {
+  if (length == 192) {
+    throw UnsupportedError('192-bit AES keys are not supported');
+  }
+  if (length != 128 && length != 256) {
+    throw const FormatException('keyData for AES must be 128 or 256 bits');
+  }
+}


### PR DESCRIPTION
Fixes #403.

Validate AES key-generation lengths at the shared Dart API boundary before dispatching to native or browser implementations.

This ensures that AES-CBC, AES-CTR, and AES-GCM consistently reject invalid lengths with `FormatException`, without exposing raw JavaScript `TypeError` objects on browser backends. The existing `UnsupportedError` behavior for 192-bit AES keys is preserved.

Regression coverage includes all three AES APIs on the VM, Chrome Dart2JS, and Chrome Dart2Wasm.

### Tests

- `dart analyze --fatal-warnings .`
- `dart test test/webcrypto_test.dart -p vm`
- `dart test test/webcrypto_test.dart -p chrome --compiler dart2js`
- `dart test test/webcrypto_test.dart -p chrome --compiler dart2wasm`
